### PR TITLE
Add search box focus shortcut

### DIFF
--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -617,6 +617,8 @@
                                                Foreground="{DynamicResource TextControlForeground}" />
                                     <TextBlock Text="Ctrl+Left/Right: Previous/Next clip"
                                                Foreground="{DynamicResource TextControlForeground}" />
+                                    <TextBlock Text="Ctrl+F or F3: Focus Search clips"
+                                               Foreground="{DynamicResource TextControlForeground}" />
                                 </StackPanel>
 
                                 <TextBlock Text="Playback notes"

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -488,8 +488,17 @@ public partial class MainWindow : Window
 
     private async Task<bool> HandleKeyDownAsync(Key key, ModifierKeys modifiers)
     {
+        if ((key == Key.F && modifiers == ModifierKeys.Control) ||
+            (key == Key.F3 && modifiers == ModifierKeys.None))
+        {
+            FocusSearchBox();
+            return true;
+        }
+
         if (_playerController is null)
+        {
             return false;
+        }
 
         switch (key)
         {
@@ -528,6 +537,13 @@ public partial class MainWindow : Window
         }
 
         return false;
+    }
+
+    private void FocusSearchBox()
+    {
+        ShowAboutPage = false;
+        SearchBox.Focus();
+        SearchBox.SelectAll();
     }
 
     private void BeginSeek()


### PR DESCRIPTION
Adds keyboard shortcuts for jumping directly to the clip search box.

- Handles `Ctrl+F` and `F3` from the main window key handler
- Focuses and selects the current `Search clips` query so the user can immediately type
- Documents the shortcut in the About/Help shortcuts list
