### PR TITLE
Add clip list context menu

### DIFF
--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -173,6 +173,23 @@
                             <Setter Property="Margin" Value="4" />
                             <Setter Property="Background" Value="{DynamicResource ControlFillColorDefaultBrush}" />
                             <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+                            <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource AncestorType=ListBox}}" />
+                            <Setter Property="ContextMenu">
+                                <Setter.Value>
+                                    <ContextMenu>
+                                        <MenuItem Header="Open Clip Folder"
+                                                  Command="{Binding PlacementTarget.Tag.OpenClipFolderCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                                  CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                        <Separator />
+                                        <MenuItem Header="Copy Folder Path"
+                                                  Command="{Binding PlacementTarget.Tag.CopyClipPathCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                                  CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                        <MenuItem Header="Copy Clip Name"
+                                                  Command="{Binding PlacementTarget.Tag.CopyClipNameCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                                  CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                    </ContextMenu>
+                                </Setter.Value>
+                            </Setter>
                             <Setter Property="Template">
                                 <Setter.Value>
                                     <ControlTemplate TargetType="ListBoxItem">

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Input;
@@ -40,6 +41,9 @@ public partial class MainWindow : Window
         DownloadFFmpegCommand = new AsyncRelayCommand(DownloadFFmpegAsync);
         DismissErrorCommand = new RelayCommand(ClearError);
         ToggleAboutCommand = new RelayCommand(ToggleAbout);
+        OpenClipFolderCommand = new RelayCommand<CamClip>(OpenClipFolder, CanUseClip);
+        CopyClipPathCommand = new RelayCommand<CamClip>(CopyClipPath, CanUseClip);
+        CopyClipNameCommand = new RelayCommand<CamClip>(CopyClipName, CanUseClip);
     }
 
     public IAsyncRelayCommand OpenFolderCommand { get; }
@@ -50,6 +54,9 @@ public partial class MainWindow : Window
     public IAsyncRelayCommand DownloadFFmpegCommand { get; }
     public IRelayCommand DismissErrorCommand { get; }
     public IRelayCommand ToggleAboutCommand { get; }
+    public IRelayCommand<CamClip> OpenClipFolderCommand { get; }
+    public IRelayCommand<CamClip> CopyClipPathCommand { get; }
+    public IRelayCommand<CamClip> CopyClipNameCommand { get; }
 
     public bool ShowMainContent => !ShowAboutPage;
 
@@ -675,6 +682,50 @@ public partial class MainWindow : Window
     private void ToggleAbout()
     {
         ShowAboutPage = !ShowAboutPage;
+    }
+
+    private static bool CanUseClip(CamClip clip)
+    {
+        return clip is not null;
+    }
+
+    private void OpenClipFolder(CamClip clip)
+    {
+        if (clip is null)
+        {
+            return;
+        }
+
+        if (!Directory.Exists(clip.FullPath))
+        {
+            ShowError("Clip Folder Not Found", $"Could not find folder:\n{clip.FullPath}");
+            return;
+        }
+
+        Process.Start(new ProcessStartInfo(clip.FullPath)
+        {
+            UseShellExecute = true,
+        });
+    }
+
+    private void CopyClipPath(CamClip clip)
+    {
+        if (clip is null)
+        {
+            return;
+        }
+
+        Clipboard.SetText(clip.FullPath);
+    }
+
+    private void CopyClipName(CamClip clip)
+    {
+        if (clip is null)
+        {
+            return;
+        }
+
+        Clipboard.SetText(clip.Name);
     }
 
     private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)


### PR DESCRIPTION
Adds a right-click context menu to clips in the main list.

- Adds `Open Clip Folder` for opening the selected clip directory in File Explorer
- Adds `Copy Folder Path` for copying the clip folder path
- Adds `Copy Clip Name` for copying the display name
- Shows the existing error overlay if the clip folder no longer exists

<img width="455" height="315" alt="image" src="https://github.com/user-attachments/assets/157cc09c-ad9d-4c82-b8ad-49aa777ab86c" />