### PR TITLE
Add update checker

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,7 @@
     <Authors>Daniel Chalmers</Authors>
     <Copyright>© Daniel Chalmers</Copyright>
     <Product>Sentry Replay for Windows</Product>
+    <Version>0.0.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/SentryReplay.Tests/UpdateServiceTests.cs
+++ b/SentryReplay.Tests/UpdateServiceTests.cs
@@ -1,0 +1,139 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace SentryReplay.Tests;
+
+public sealed class UpdateServiceTests
+{
+    [Theory]
+    [InlineData("1.2.3", 1, 2, 3)]
+    [InlineData("v1.2.3", 1, 2, 3)]
+    [InlineData("V1.2.3", 1, 2, 3)]
+    [InlineData("  v1.2.3  ", 1, 2, 3)]
+    public void TryParseVersion_AcceptsVersionTags(string tagName, int major, int minor, int build)
+    {
+        var version = UpdateService.TryParseVersion(tagName);
+
+        version.ShouldNotBeNull();
+        version.Major.ShouldBe(major);
+        version.Minor.ShouldBe(minor);
+        version.Build.ShouldBe(build);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("version1")]
+    [InlineData("v1.2.3-beta1")]
+    [InlineData("1.2.3+build")]
+    public void TryParseVersion_IgnoresTagsVersionCannotParseDirectly(string tagName)
+    {
+        var version = UpdateService.TryParseVersion(tagName);
+
+        version.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetLatestRelease_ReturnsHighestParseableNonDraftRelease()
+    {
+        var payload = """
+        [
+            {
+                "tag_name": "v1.2.3-beta1",
+                "name": "Beta",
+                "html_url": "https://example.test/beta",
+                "draft": false
+            },
+            {
+                "tag_name": "v2.0.0",
+                "name": "Draft",
+                "html_url": "https://example.test/draft",
+                "draft": true
+            },
+            {
+                "tag_name": "v1.4.0",
+                "name": "Current",
+                "html_url": "https://example.test/current",
+                "draft": false
+            },
+            {
+                "tag_name": "1.3.0",
+                "name": "Previous",
+                "html_url": "https://example.test/previous",
+                "draft": false
+            }
+        ]
+        """;
+
+        var release = UpdateService.GetLatestRelease(payload);
+
+        release.ShouldNotBeNull();
+        release.Version.ShouldBe(new Version(1, 4, 0));
+        release.Name.ShouldBe("Current");
+        release.ReleaseUrl.ShouldBe("https://example.test/current");
+    }
+
+    [Fact]
+    public void IsUpdateAvailable_ReturnsTrueOnlyForHigherLatestVersion()
+    {
+        UpdateService.IsUpdateAvailable(new Version(1, 2, 3), new Version(1, 2, 4)).ShouldBeTrue();
+        UpdateService.IsUpdateAvailable(new Version(1, 2, 3), new Version(1, 2, 3)).ShouldBeFalse();
+        UpdateService.IsUpdateAvailable(new Version(1, 2, 3), new Version(1, 2, 2)).ShouldBeFalse();
+        UpdateService.IsUpdateAvailable(null, new Version(1, 2, 4)).ShouldBeFalse();
+        UpdateService.IsUpdateAvailable(new Version(1, 2, 3), null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CheckForUpdateAsync_UsesLatestRelease()
+    {
+        var payload = """
+        [
+            {
+                "tag_name": "v1.2.4",
+                "name": "Latest",
+                "html_url": "https://example.test/latest",
+                "draft": false
+            }
+        ]
+        """;
+        var service = new UpdateService(new HttpClient(new StubHandler(payload)));
+
+        var result = await service.CheckForUpdateAsync(new Version(1, 2, 3));
+
+        result.IsUpdateAvailable.ShouldBeTrue();
+        result.LatestRelease.ShouldNotBeNull();
+        result.LatestRelease.Version.ShouldBe(new Version(1, 2, 4));
+    }
+
+    [Fact]
+    public async Task GetLatestReleaseAsync_ReturnsNullWhenGitHubRequestFails()
+    {
+        var service = new UpdateService(new HttpClient(new StubHandler("{}", HttpStatusCode.InternalServerError)));
+
+        var release = await service.GetLatestReleaseAsync();
+
+        release.ShouldBeNull();
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _payload;
+        private readonly HttpStatusCode _statusCode;
+
+        public StubHandler(string payload, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _payload = payload;
+            _statusCode = statusCode;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.RequestUri.ShouldNotBeNull();
+            request.RequestUri.ToString().ShouldBe(UpdateService.ReleasesApiUrl);
+
+            return Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_payload),
+            });
+        }
+    }
+}

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -603,7 +603,7 @@
                                             <Run Text=" " />
                                             <Hyperlink NavigateUri="{Binding LatestReleaseUrl}"
                                                        RequestNavigate="Hyperlink_RequestNavigate">
-                                                <Run Text="{Binding UpdateStatusLinkText, Mode=OneWay}" />
+                                                Learn more
                                             </Hyperlink>
                                         </TextBlock>
                                     </StackPanel>

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -262,11 +262,20 @@
                             Command="{Binding OpenFolderCommand}"
                             Padding="12"
                             Style="{StaticResource PlayerButton}" />
-                    <Button Content="ℹ️ About / Help"
-                            Command="{Binding ToggleAboutCommand}"
-                            Margin="0,8,0,0"
-                            Padding="12"
-                            Style="{StaticResource PlayerButton}" />
+                    <Grid Margin="0,8,0,0">
+                        <Button Content="ℹ️ About / Help"
+                                Command="{Binding ToggleAboutCommand}"
+                                Padding="12"
+                                Style="{StaticResource PlayerButton}" />
+                        <Border Width="9"
+                                Height="9"
+                                Margin="0,8,8,0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Top"
+                                Background="{DynamicResource AccentFillColorDefaultBrush}"
+                                CornerRadius="4.5"
+                                Visibility="{Binding HasUpdateBadge, Converter={local:BoolToVisibilityConverter}}" />
+                    </Grid>
                 </StackPanel>
             </Grid>
 
@@ -555,71 +564,116 @@
                                            Foreground="{DynamicResource TextControlForeground}"
                                            TextWrapping="Wrap" />
                             </StackPanel>
-                            <TextBlock Text="App info"
-                                       Margin="0,16,0,0"
-                                       FontSize="16"
-                                       FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextControlForeground}" />
-                            <Grid Margin="0,8,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="8" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <TextBlock Grid.Row="0"
-                                           Grid.Column="0"
-                                           Text="Version:"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextControlPlaceholderForeground}"
-                                           TextAlignment="Right" />
-                                <TextBlock Grid.Row="0"
-                                           Grid.Column="2"
-                                           Text="{Binding FileVersion}"
-                                           Foreground="{DynamicResource TextControlForeground}" />
-                                <TextBlock Grid.Row="1"
-                                           Grid.Column="0"
-                                           Text="Runtime:"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextControlPlaceholderForeground}"
-                                           TextAlignment="Right" />
-                                <TextBlock Grid.Row="1"
-                                           Grid.Column="2"
-                                           Text="{Binding RuntimeDescription}"
-                                           Foreground="{DynamicResource TextControlForeground}" />
-                                <TextBlock Grid.Row="2"
-                                           Grid.Column="0"
-                                           Text="OS:"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextControlPlaceholderForeground}"
-                                           TextAlignment="Right" />
-                                <TextBlock Grid.Row="2"
-                                           Grid.Column="2"
-                                           Text="{Binding OsDescription}"
-                                           Foreground="{DynamicResource TextControlForeground}" />
-                                <TextBlock Grid.Row="3"
-                                           Grid.Column="0"
-                                           Text="Exe:"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextControlPlaceholderForeground}"
-                                           TextAlignment="Right" />
-                                <TextBlock Grid.Row="3"
-                                           Grid.Column="2"
-                                           Text="{Binding ExecutablePath}"
-                                           Foreground="{DynamicResource TextControlForeground}"
-                                           TextWrapping="Wrap" />
-                            </Grid>
                         </StackPanel>
                     </Border>
 
                     <StackPanel Grid.Column="1"
                                 Margin="12,0,0,0">
                         <Border Padding="20"
+                                Background="{DynamicResource ControlAltFillColorSecondaryBrush}"
+                                CornerRadius="8">
+                            <StackPanel>
+                                <TextBlock Text="Updates"
+                                           FontSize="16"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextControlForeground}" />
+                                <Grid Margin="0,8,0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="12" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Border Grid.Column="0"
+                                            Width="12"
+                                            Height="12"
+                                            Margin="0,4,0,0"
+                                            VerticalAlignment="Top"
+                                            Background="{DynamicResource AccentFillColorDefaultBrush}"
+                                            CornerRadius="6"
+                                            Visibility="{Binding HasUpdateBadge, Converter={local:BoolToVisibilityConverter}}" />
+                                    <StackPanel Grid.Column="2">
+                                        <TextBlock Text="{Binding UpdateStatusTitle}"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource TextControlForeground}"
+                                                   TextWrapping="Wrap" />
+                                        <TextBlock Text="{Binding UpdateStatusDetails}"
+                                                   Margin="0,4,0,0"
+                                                   Foreground="{DynamicResource TextControlForeground}"
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
+                                </Grid>
+                                <StackPanel Margin="0,0,0,16"
+                                            Orientation="Horizontal">
+                                    <Button Content="Check again"
+                                            Command="{Binding CheckForUpdatesCommand}"
+                                            Padding="12,8"
+                                            Style="{StaticResource PlayerButton}" />
+                                    <TextBlock Margin="12,8,0,0">
+                                        <Hyperlink NavigateUri="{Binding LatestReleaseUrl}"
+                                                   RequestNavigate="Hyperlink_RequestNavigate">
+                                            Open releases
+                                        </Hyperlink>
+                                    </TextBlock>
+                                </StackPanel>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="8" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Grid.Row="0"
+                                               Grid.Column="0"
+                                               Text="Version:"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextControlPlaceholderForeground}"
+                                               TextAlignment="Right" />
+                                    <TextBlock Grid.Row="0"
+                                               Grid.Column="2"
+                                               Text="{Binding FileVersion}"
+                                               Foreground="{DynamicResource TextControlForeground}" />
+                                    <TextBlock Grid.Row="1"
+                                               Grid.Column="0"
+                                               Text="Runtime:"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextControlPlaceholderForeground}"
+                                               TextAlignment="Right" />
+                                    <TextBlock Grid.Row="1"
+                                               Grid.Column="2"
+                                               Text="{Binding RuntimeDescription}"
+                                               Foreground="{DynamicResource TextControlForeground}" />
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="0"
+                                               Text="OS:"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextControlPlaceholderForeground}"
+                                               TextAlignment="Right" />
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="2"
+                                               Text="{Binding OsDescription}"
+                                               Foreground="{DynamicResource TextControlForeground}" />
+                                    <TextBlock Grid.Row="3"
+                                               Grid.Column="0"
+                                               Text="Exe:"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextControlPlaceholderForeground}"
+                                               TextAlignment="Right" />
+                                    <TextBlock Grid.Row="3"
+                                               Grid.Column="2"
+                                               Text="{Binding ExecutablePath}"
+                                               Foreground="{DynamicResource TextControlForeground}"
+                                               TextWrapping="Wrap" />
+                                </Grid>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Margin="0,12,0,0"
+                                Padding="20"
                                 Background="{DynamicResource ControlAltFillColorSecondaryBrush}"
                                 CornerRadius="8">
                             <StackPanel>
@@ -674,12 +728,6 @@
                                         <Hyperlink NavigateUri="https://github.com/danielchalmers/SentryReplay/issues"
                                                    RequestNavigate="Hyperlink_RequestNavigate">
                                             🐛 Report a Bug / Request a Feature
-                                        </Hyperlink>
-                                    </TextBlock>
-                                    <TextBlock>
-                                        <Hyperlink NavigateUri="https://github.com/danielchalmers/SentryReplay/releases"
-                                                   RequestNavigate="Hyperlink_RequestNavigate">
-                                            🚀 Check for Updates
                                         </Hyperlink>
                                     </TextBlock>
                                 </StackPanel>

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -596,18 +596,18 @@
                                                    FontWeight="SemiBold"
                                                    Foreground="{DynamicResource TextControlForeground}"
                                                    TextWrapping="Wrap" />
-                                        <TextBlock Text="{Binding UpdateStatusDetails}"
-                                                   Margin="0,4,0,0"
+                                        <TextBlock Margin="0,4,0,0"
                                                    Foreground="{DynamicResource TextControlForeground}"
-                                                   TextWrapping="Wrap" />
+                                                   TextWrapping="Wrap">
+                                            <Run Text="{Binding UpdateStatusDetails}" />
+                                            <Run Text=" " />
+                                            <Hyperlink NavigateUri="{Binding LatestReleaseUrl}"
+                                                       RequestNavigate="Hyperlink_RequestNavigate">
+                                                <Run Text="{Binding UpdateStatusLinkText}" />
+                                            </Hyperlink>
+                                        </TextBlock>
                                     </StackPanel>
                                 </Grid>
-                                <TextBlock Margin="0,0,0,16">
-                                    <Hyperlink NavigateUri="{Binding LatestReleaseUrl}"
-                                               RequestNavigate="Hyperlink_RequestNavigate">
-                                        Open releases
-                                    </Hyperlink>
-                                </TextBlock>
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -573,7 +573,7 @@
                                 Background="{DynamicResource ControlAltFillColorSecondaryBrush}"
                                 CornerRadius="8">
                             <StackPanel>
-                                <TextBlock Text="Updates"
+                                <TextBlock Text="App Info"
                                            FontSize="16"
                                            FontWeight="SemiBold"
                                            Foreground="{DynamicResource TextControlForeground}" />

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -599,11 +599,11 @@
                                         <TextBlock Margin="0,4,0,0"
                                                    Foreground="{DynamicResource TextControlForeground}"
                                                    TextWrapping="Wrap">
-                                            <Run Text="{Binding UpdateStatusDetails}" />
+                                            <Run Text="{Binding UpdateStatusDetails, Mode=OneWay}" />
                                             <Run Text=" " />
                                             <Hyperlink NavigateUri="{Binding LatestReleaseUrl}"
                                                        RequestNavigate="Hyperlink_RequestNavigate">
-                                                <Run Text="{Binding UpdateStatusLinkText}" />
+                                                <Run Text="{Binding UpdateStatusLinkText, Mode=OneWay}" />
                                             </Hyperlink>
                                         </TextBlock>
                                     </StackPanel>

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -602,19 +602,12 @@
                                                    TextWrapping="Wrap" />
                                     </StackPanel>
                                 </Grid>
-                                <StackPanel Margin="0,0,0,16"
-                                            Orientation="Horizontal">
-                                    <Button Content="Check again"
-                                            Command="{Binding CheckForUpdatesCommand}"
-                                            Padding="12,8"
-                                            Style="{StaticResource PlayerButton}" />
-                                    <TextBlock Margin="12,8,0,0">
-                                        <Hyperlink NavigateUri="{Binding LatestReleaseUrl}"
-                                                   RequestNavigate="Hyperlink_RequestNavigate">
-                                            Open releases
-                                        </Hyperlink>
-                                    </TextBlock>
-                                </StackPanel>
+                                <TextBlock Margin="0,0,0,16">
+                                    <Hyperlink NavigateUri="{Binding LatestReleaseUrl}"
+                                               RequestNavigate="Hyperlink_RequestNavigate">
+                                        Open releases
+                                    </Hyperlink>
+                                </TextBlock>
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -267,7 +267,11 @@ public partial class MainWindow : Window
         _isInitialized = true;
         Log.Debug("Initializing main window");
 
+#if DEBUG
+        Log.Debug("Skipping update check in debug build");
+#else
         _ = UpdateLatestReleaseAsync();
+#endif
 
         if (TryStartFlyleaf())
         {

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -46,21 +46,17 @@ public partial class MainWindow : Window
     public string LatestVersionText => LatestRelease is null ? "Unknown" : FormatVersion(LatestRelease.Version);
     public string LatestReleaseUrl => LatestRelease?.ReleaseUrl ?? UpdateService.ReleasesPageUrl;
     public string ReleasesPageUrl => UpdateService.ReleasesPageUrl;
-    public string UpdateStatusTitle => IsCheckingForUpdates
-        ? "Checking for updates"
-        : IsUpdateAvailable
-            ? "Update available"
-            : HasCheckedForUpdates
-                ? "You're up to date"
-                : "Updates";
+    public string UpdateStatusTitle => IsUpdateAvailable
+        ? "Update available"
+        : HasCheckedForUpdates
+            ? "You're up to date"
+            : "Updates";
 
-    public string UpdateStatusDetails => IsCheckingForUpdates
-        ? "Looking for the latest Sentry Replay release."
-        : IsUpdateAvailable
-            ? $"Version {LatestVersionText} is available."
-            : HasCheckedForUpdates
-                ? "No newer release was found."
-                : "Updates are checked after launch.";
+    public string UpdateStatusDetails => IsUpdateAvailable
+        ? $"Version {LatestVersionText} is available."
+        : HasCheckedForUpdates
+            ? "No newer release was found."
+            : "Updates are checked after launch.";
 
     public IReadOnlyList<double> PlaybackSpeedOptions { get; } =
     [
@@ -204,11 +200,6 @@ public partial class MainWindow : Window
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(UpdateStatusTitle))]
     [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
-    private bool _isCheckingForUpdates;
-
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(UpdateStatusTitle))]
-    [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
     private bool _hasCheckedForUpdates;
 
     [ObservableProperty]
@@ -268,7 +259,7 @@ public partial class MainWindow : Window
         _isInitialized = true;
         Log.Debug("Initializing main window");
 
-        _ = CheckForUpdatesAsync();
+        _ = UpdateLatestReleaseAsync();
 
         if (TryStartFlyleaf())
         {
@@ -751,28 +742,18 @@ public partial class MainWindow : Window
         ShowAboutPage = !ShowAboutPage;
     }
 
-    [RelayCommand(AllowConcurrentExecutions = false)]
-    private async Task CheckForUpdatesAsync()
+    private async Task UpdateLatestReleaseAsync()
     {
-        IsCheckingForUpdates = true;
+        var result = await _updateService.CheckForUpdateAsync(CurrentVersion);
+        LatestRelease = result.LatestRelease;
+        IsUpdateAvailable = result.IsUpdateAvailable;
+        HasCheckedForUpdates = true;
 
-        try
-        {
-            var result = await _updateService.CheckForUpdateAsync(CurrentVersion);
-            LatestRelease = result.LatestRelease;
-            IsUpdateAvailable = result.IsUpdateAvailable;
-            HasCheckedForUpdates = true;
-
-            Log.Information(
-                "Checked for updates. CurrentVersion={CurrentVersion}; LatestVersion={LatestVersion}; IsUpdateAvailable={IsUpdateAvailable}",
-                FormatVersion(CurrentVersion),
-                LatestVersionText,
-                IsUpdateAvailable);
-        }
-        finally
-        {
-            IsCheckingForUpdates = false;
-        }
+        Log.Information(
+            "Checked for updates. CurrentVersion={CurrentVersion}; LatestVersion={LatestVersion}; IsUpdateAvailable={IsUpdateAvailable}",
+            FormatVersion(CurrentVersion),
+            LatestVersionText,
+            IsUpdateAvailable);
     }
 
     private static bool CanUseClip(CamClip clip)

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -58,6 +58,12 @@ public partial class MainWindow : Window
             ? "No newer release was found."
             : "Updates are checked after launch.";
 
+    public string UpdateStatusLinkText => IsUpdateAvailable
+        ? "Learn more"
+        : HasCheckedForUpdates
+            ? "View all releases"
+            : string.Empty;
+
     public IReadOnlyList<double> PlaybackSpeedOptions { get; } =
     [
         0.25,
@@ -195,11 +201,13 @@ public partial class MainWindow : Window
     [NotifyPropertyChangedFor(nameof(HasUpdateBadge))]
     [NotifyPropertyChangedFor(nameof(UpdateStatusTitle))]
     [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
+    [NotifyPropertyChangedFor(nameof(UpdateStatusLinkText))]
     private bool _isUpdateAvailable;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(UpdateStatusTitle))]
     [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
+    [NotifyPropertyChangedFor(nameof(UpdateStatusLinkText))]
     private bool _hasCheckedForUpdates;
 
     [ObservableProperty]

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -48,21 +48,11 @@ public partial class MainWindow : Window
     public string ReleasesPageUrl => UpdateService.ReleasesPageUrl;
     public string UpdateStatusTitle => IsUpdateAvailable
         ? "Update available"
-        : HasCheckedForUpdates
-            ? "You're up to date"
-            : "Updates";
+        : "You're up to date";
 
     public string UpdateStatusDetails => IsUpdateAvailable
         ? $"Version {LatestVersionText} is available."
-        : HasCheckedForUpdates
-            ? "No newer release was found."
-            : "Updates are checked after launch.";
-
-    public string UpdateStatusLinkText => IsUpdateAvailable
-        ? "Learn more"
-        : HasCheckedForUpdates
-            ? "View all releases"
-            : string.Empty;
+        : "No newer release was found.";
 
     public IReadOnlyList<double> PlaybackSpeedOptions { get; } =
     [
@@ -201,14 +191,7 @@ public partial class MainWindow : Window
     [NotifyPropertyChangedFor(nameof(HasUpdateBadge))]
     [NotifyPropertyChangedFor(nameof(UpdateStatusTitle))]
     [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
-    [NotifyPropertyChangedFor(nameof(UpdateStatusLinkText))]
     private bool _isUpdateAvailable;
-
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(UpdateStatusTitle))]
-    [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
-    [NotifyPropertyChangedFor(nameof(UpdateStatusLinkText))]
-    private bool _hasCheckedForUpdates;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(LatestVersionText))]
@@ -759,7 +742,6 @@ public partial class MainWindow : Window
         var result = await _updateService.CheckForUpdateAsync(CurrentVersion);
         LatestRelease = result.LatestRelease;
         IsUpdateAvailable = result.IsUpdateAvailable;
-        HasCheckedForUpdates = true;
 
         Log.Information(
             "Checked for updates. CurrentVersion={CurrentVersion}; LatestVersion={LatestVersion}; IsUpdateAvailable={IsUpdateAvailable}",

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Input;
@@ -22,6 +23,7 @@ namespace SentryReplay;
 public partial class MainWindow : Window
 {
     private readonly List<CamClip> AllClips = [];
+    private readonly UpdateService _updateService = new();
     private VideoPlayerController _playerController;
     private bool _isSeeking;
     private bool _isInitialized;
@@ -35,10 +37,30 @@ public partial class MainWindow : Window
 
     public bool ShowMainContent => !ShowAboutPage;
 
-    public string FileVersion => FileVersionInfo.GetVersionInfo(Environment.ProcessPath)?.FileVersion ?? "Unknown";
+    public Version CurrentVersion => Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0, 0);
+    public string FileVersion => FormatVersion(CurrentVersion);
     public string RuntimeDescription => $"{RuntimeInformation.FrameworkDescription} ({RuntimeInformation.ProcessArchitecture})";
     public string OsDescription => RuntimeInformation.OSDescription;
     public string ExecutablePath => Environment.ProcessPath;
+    public bool HasUpdateBadge => IsUpdateAvailable;
+    public string LatestVersionText => LatestRelease is null ? "Unknown" : FormatVersion(LatestRelease.Version);
+    public string LatestReleaseUrl => LatestRelease?.ReleaseUrl ?? UpdateService.ReleasesPageUrl;
+    public string ReleasesPageUrl => UpdateService.ReleasesPageUrl;
+    public string UpdateStatusTitle => IsCheckingForUpdates
+        ? "Checking for updates"
+        : IsUpdateAvailable
+            ? "Update available"
+            : HasCheckedForUpdates
+                ? "You're up to date"
+                : "Updates";
+
+    public string UpdateStatusDetails => IsCheckingForUpdates
+        ? "Looking for the latest Sentry Replay release."
+        : IsUpdateAvailable
+            ? $"Version {LatestVersionText} is available."
+            : HasCheckedForUpdates
+                ? "No newer release was found."
+                : "Updates are checked after launch.";
 
     public IReadOnlyList<double> PlaybackSpeedOptions { get; } =
     [
@@ -173,6 +195,28 @@ public partial class MainWindow : Window
     [ObservableProperty]
     private double _selectedPlaybackSpeed = 1.0;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasUpdateBadge))]
+    [NotifyPropertyChangedFor(nameof(UpdateStatusTitle))]
+    [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
+    private bool _isUpdateAvailable;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UpdateStatusTitle))]
+    [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
+    private bool _isCheckingForUpdates;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UpdateStatusTitle))]
+    [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
+    private bool _hasCheckedForUpdates;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(LatestVersionText))]
+    [NotifyPropertyChangedFor(nameof(LatestReleaseUrl))]
+    [NotifyPropertyChangedFor(nameof(UpdateStatusDetails))]
+    private UpdateRelease _latestRelease;
+
     private async void Window_ContentRendered(object sender, EventArgs e)
     {
         await InitializeAsync();
@@ -223,6 +267,8 @@ public partial class MainWindow : Window
 
         _isInitialized = true;
         Log.Debug("Initializing main window");
+
+        _ = CheckForUpdatesAsync();
 
         if (TryStartFlyleaf())
         {
@@ -652,6 +698,23 @@ public partial class MainWindow : Window
             : ts.ToString(@"m\:ss");
     }
 
+    private static string FormatVersion(Version version)
+    {
+        if (version is null)
+        {
+            return "Unknown";
+        }
+
+        if (version.Revision >= 0)
+        {
+            return version.ToString(4);
+        }
+
+        return version.Build >= 0
+            ? version.ToString(3)
+            : version.ToString(2);
+    }
+
     private void ShowError(string title, string details, bool canDismiss = true)
     {
         ErrorTitle = title;
@@ -686,6 +749,30 @@ public partial class MainWindow : Window
     private void ToggleAbout()
     {
         ShowAboutPage = !ShowAboutPage;
+    }
+
+    [RelayCommand(AllowConcurrentExecutions = false)]
+    private async Task CheckForUpdatesAsync()
+    {
+        IsCheckingForUpdates = true;
+
+        try
+        {
+            var result = await _updateService.CheckForUpdateAsync(CurrentVersion);
+            LatestRelease = result.LatestRelease;
+            IsUpdateAvailable = result.IsUpdateAvailable;
+            HasCheckedForUpdates = true;
+
+            Log.Information(
+                "Checked for updates. CurrentVersion={CurrentVersion}; LatestVersion={LatestVersion}; IsUpdateAvailable={IsUpdateAvailable}",
+                FormatVersion(CurrentVersion),
+                LatestVersionText,
+                IsUpdateAvailable);
+        }
+        finally
+        {
+            IsCheckingForUpdates = false;
+        }
     }
 
     private static bool CanUseClip(CamClip clip)

--- a/SentryReplay/UpdateService.cs
+++ b/SentryReplay/UpdateService.cs
@@ -1,0 +1,136 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Serilog;
+
+namespace SentryReplay;
+
+public sealed class UpdateService
+{
+    public const string ReleasesApiUrl = "https://api.github.com/repos/danielchalmers/SentryReplay/releases";
+    public const string ReleasesPageUrl = "https://github.com/danielchalmers/SentryReplay/releases";
+
+    private readonly HttpClient _httpClient;
+
+    public UpdateService()
+        : this(CreateHttpClient())
+    {
+    }
+
+    public UpdateService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<UpdateCheckResult> CheckForUpdateAsync(Version currentVersion, CancellationToken cancellationToken = default)
+    {
+        var latestRelease = await GetLatestReleaseAsync(cancellationToken).ConfigureAwait(false);
+        return new UpdateCheckResult(currentVersion, latestRelease, IsUpdateAvailable(currentVersion, latestRelease?.Version));
+    }
+
+    public async Task<UpdateRelease> GetLatestReleaseAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _httpClient.GetAsync(ReleasesApiUrl, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                Log.Warning("Update check failed with status code {StatusCode}", response.StatusCode);
+                return null;
+            }
+
+            var payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var latestRelease = GetLatestRelease(payload);
+            if (latestRelease is null)
+            {
+                Log.Warning("Update check did not return a parseable release version");
+            }
+
+            return latestRelease;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to check for updates");
+            return null;
+        }
+    }
+
+    public static bool IsUpdateAvailable(Version currentVersion, Version latestVersion)
+    {
+        if (currentVersion is null || latestVersion is null)
+        {
+            return false;
+        }
+
+        return latestVersion > currentVersion;
+    }
+
+    public static UpdateRelease GetLatestRelease(string payload)
+    {
+        var releases = JsonSerializer.Deserialize<List<GitHubRelease>>(payload);
+        if (releases is null)
+        {
+            return null;
+        }
+
+        return releases
+            .Where(release => !release.Draft)
+            .Select(release => new UpdateRelease(
+                TryParseVersion(release.TagName),
+                release.Name,
+                string.IsNullOrWhiteSpace(release.HtmlUrl) ? ReleasesPageUrl : release.HtmlUrl))
+            .Where(release => release.Version is not null)
+            .OrderByDescending(release => release.Version)
+            .FirstOrDefault();
+    }
+
+    public static Version TryParseVersion(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var normalized = value.Trim();
+        if (normalized.StartsWith('v') || normalized.StartsWith('V'))
+        {
+            normalized = normalized[1..];
+        }
+
+        return Version.TryParse(normalized, out var version)
+            ? version
+            : null;
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var client = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(10),
+        };
+
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("SentryReplay");
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        return client;
+    }
+
+    private sealed class GitHubRelease
+    {
+        [JsonPropertyName("tag_name")]
+        public string TagName { get; init; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; }
+
+        [JsonPropertyName("html_url")]
+        public string HtmlUrl { get; init; }
+
+        [JsonPropertyName("draft")]
+        public bool Draft { get; init; }
+    }
+}
+
+public sealed record UpdateRelease(Version Version, string Name, string ReleaseUrl);
+
+public sealed record UpdateCheckResult(Version CurrentVersion, UpdateRelease LatestRelease, bool IsUpdateAvailable);


### PR DESCRIPTION
Summary
- add a minimal GitHub releases update service for Sentry Replay
- set the working project version to `0.0.0`
- check for updates after launch in non-debug builds and show an About / Help badge plus an App Info card
- skip the automatic GitHub update check in debug builds to avoid API traffic during testing
- move app info into the App Info card and remove the old Support update link
- show release navigation inline with the update status using a constant `Learn more` link
- add update service coverage for tag parsing, release selection, comparison, and HTTP failure handling

Closes #4

<img width="1186" height="693" alt="image" src="https://github.com/user-attachments/assets/f0ca3c6a-c5cd-40fd-ba0b-af74a2cab7c3" />

<img width="1186" height="693" alt="image" src="https://github.com/user-attachments/assets/8062ad67-a641-468e-813f-cd2fc9c4d151" />

<img width="1186" height="693" alt="image" src="https://github.com/user-attachments/assets/96807bdd-9e6b-4380-8be3-ce317c62bd2a" />
