### PR TITLE
Fix UI freeze while loading clip

### DIFF
--- a/SentryReplay.Tests/VideoPlayerControllerTests.cs
+++ b/SentryReplay.Tests/VideoPlayerControllerTests.cs
@@ -237,6 +237,31 @@ public sealed class VideoPlayerControllerTests
     }
 
     [Fact]
+    public async Task GoToClipAsync_ShowsLoadingWhileCurrentClipStops()
+    {
+        using var firstClipFiles = TestClipFiles.Create(chunkCount: 1);
+        using var secondClipFiles = TestClipFiles.Create(chunkCount: 1);
+        var front = new FakeCameraPlayer();
+        using var controller = CreateController(front);
+
+        controller.LoadClips([firstClipFiles.Clip, secondClipFiles.Clip]);
+        controller.Playlist.MoveTo(0);
+        await WaitUntilAsync(() => front.PlayCount > 0);
+
+        front.StopGate = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var changeClipTask = controller.GoToClipAsync(secondClipFiles.Clip);
+
+        await WaitUntilAsync(() => front.StopCount > 0);
+
+        controller.IsLoading.ShouldBeTrue();
+
+        front.StopGate.SetResult(null);
+        await changeClipTask;
+        await WaitUntilAsync(() => controller.CurrentClip == secondClipFiles.Clip);
+    }
+
+    [Fact]
     public async Task LoadClipsAsync_StopsCurrentPlaybackAndResetsSelection()
     {
         using var firstClipFiles = TestClipFiles.Create(chunkCount: 1);
@@ -292,6 +317,7 @@ public sealed class VideoPlayerControllerTests
         public List<TimeSpan> SeekPositions { get; } = [];
         public bool OpenResult { get; init; } = true;
         public bool ThrowOnStop { get; init; }
+        public TaskCompletionSource<object> StopGate { get; set; }
         public bool IsOpen { get; private set; }
         public double Speed { get; set; } = 1.0;
         public int PlayCount { get; private set; }
@@ -328,6 +354,11 @@ public sealed class VideoPlayerControllerTests
         public Task StopAsync()
         {
             StopCount++;
+            if (StopGate is not null)
+            {
+                return StopGate.Task;
+            }
+
             return ThrowOnStop
                 ? Task.FromException(new InvalidOperationException("stop failed"))
                 : Task.CompletedTask;

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using FlyleafLib.Controls.WPF;
@@ -535,6 +536,8 @@ public partial class MainWindow : Window
             return;
 
         ClearError();
+        IsLoading = true;
+        await Dispatcher.Yield(DispatcherPriority.Background);
 
         try
         {
@@ -542,6 +545,7 @@ public partial class MainWindow : Window
         }
         catch (Exception ex)
         {
+            IsLoading = false;
             Log.Error(
                 ex,
                 "Failed to play selected clip. ClipName={ClipName}; ClipPath={ClipPath}",

--- a/SentryReplay/Playback/FlyleafCameraPlayer.cs
+++ b/SentryReplay/Playback/FlyleafCameraPlayer.cs
@@ -99,14 +99,12 @@ internal sealed class FlyleafCameraPlayer : ICameraPlayer
 
     public Task StopAsync()
     {
-        StopAndClose();
-        return Task.CompletedTask;
+        return Task.Run(StopAndClose);
     }
 
     public Task CloseAsync()
     {
-        StopAndClose();
-        return Task.CompletedTask;
+        return Task.Run(StopAndClose);
     }
 
     public Task SeekAsync(TimeSpan position)

--- a/SentryReplay/Playback/VideoPlayerController.cs
+++ b/SentryReplay/Playback/VideoPlayerController.cs
@@ -214,7 +214,7 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
         if (!Playlist.HasNext)
             return;
 
-        await StopAsync();
+        await PrepareForClipChangeAsync();
         Playlist.MoveNext();
     }
 
@@ -223,27 +223,25 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
         if (!Playlist.HasPrevious)
             return;
 
-        await StopAsync();
+        await PrepareForClipChangeAsync();
         Playlist.MovePrevious();
     }
 
     public async Task GoToClipAsync(CamClip clip)
     {
-        if (clip is null || clip == Playlist.CurrentClip)
+        if (clip is null || clip == Playlist.CurrentClip || !Playlist.Clips.Contains(clip))
             return;
 
-        BeginNewRequest();
-        await StopAsync();
+        await PrepareForClipChangeAsync();
         Playlist.MoveTo(clip);
     }
 
     public async Task GoToClipAsync(int index)
     {
-        if (index == Playlist.CurrentIndex)
+        if (index == Playlist.CurrentIndex || index < 0 || index >= Playlist.Clips.Count)
             return;
 
-        BeginNewRequest();
-        await StopAsync();
+        await PrepareForClipChangeAsync();
         Playlist.MoveTo(index);
     }
 
@@ -334,6 +332,21 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
         cts.Dispose();
     }
 
+    private async Task PrepareForClipChangeAsync()
+    {
+        BeginNewRequest();
+        CancelAndDisposePlaybackCts();
+        ErrorMessage = null;
+        IsLoading = true;
+
+        await Task.Yield();
+
+        await RunSerializedPlaybackOperationAsync(async _ =>
+        {
+            await StopPlaybackInternalAsync(resetTimeline: true, clearLoading: false);
+        });
+    }
+
     private async Task PlayInternalAsync(long requestId, CamClip clip)
     {
         if (clip is null)
@@ -399,7 +412,7 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
         }
     }
 
-    private async Task StopPlaybackInternalAsync(bool resetTimeline)
+    private async Task StopPlaybackInternalAsync(bool resetTimeline, bool clearLoading = true)
     {
         Volatile.Write(ref _currentMediaRequestId, 0);
         await StopAndClosePlayersAsync();
@@ -410,7 +423,11 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
 
         if (resetTimeline)
         {
-            IsLoading = false;
+            if (clearLoading)
+            {
+                IsLoading = false;
+            }
+
             IsPlaying = false;
             Position = TimeSpan.Zero;
             Duration = TimeSpan.Zero;


### PR DESCRIPTION
## Summary
- Show the loading overlay immediately when a sidebar clip selection starts playback preparation.
- Keep playback loading active while the current clip is stopped and the next clip is prepared.
- Move Flyleaf stop/close cleanup off the UI thread.
- Add a regression test for clip changes while player cleanup is still pending.

## Root Cause
Selecting a clip waited for the existing playback stop/close path before the controller raised its loading state for the new clip. When Flyleaf cleanup was slow, the UI could appear frozen and the loading overlay did not render until after the expensive work had already completed.

## Validation
- `dotnet test .\SentryReplay.slnx`
- `dotnet format .\SentryReplay.slnx --verify-no-changes`

## UI Verification
Open the app, start playback, then click another clip in the sidebar. The loading overlay should appear immediately while the next clip gets ready.
