### PR TITLE
Make the UI fluid: async clip loading, animations, smoother clip switching

### DIFF
--- a/SentryReplay.Tests/MainWindowViewModelTests.cs
+++ b/SentryReplay.Tests/MainWindowViewModelTests.cs
@@ -279,22 +279,22 @@ public sealed class MainWindowViewModelTests
     // --- Clip browsing: the injectable clip loader lets us populate clips without disk I/O ---
 
     [Fact]
-    public void FilteredClips_OrderNewestFirst()
+    public async Task FilteredClips_OrderNewestFirst()
     {
         var clips = TestClips.Create(3); // timestamps increase with index
         var vm = new MainWindowViewModel(() => null!, clipLoader: _ => clips);
 
-        vm.LoadClips(new[] { "root" });
+        await vm.LoadClipsAsync(new[] { "root" });
 
         vm.FilteredClips.Select(c => c.Name).ShouldBe(new[] { "Clip 2", "Clip 1", "Clip 0" });
     }
 
     [Fact]
-    public void FilteredClips_FiltersByNameCaseInsensitively()
+    public async Task FilteredClips_FiltersByNameCaseInsensitively()
     {
         var clips = TestClips.Create(3);
         var vm = new MainWindowViewModel(() => null!, clipLoader: _ => clips);
-        vm.LoadClips(new[] { "root" });
+        await vm.LoadClipsAsync(new[] { "root" });
 
         vm.FilterText = "clip 1";
 
@@ -302,12 +302,12 @@ public sealed class MainWindowViewModelTests
     }
 
     [Fact]
-    public void FilteredClips_FiltersByPath()
+    public async Task FilteredClips_FiltersByPath()
     {
         // TestClips share a folder path but have distinct names, so a path-only match keeps them all.
         var clips = TestClips.Create(2);
         var vm = new MainWindowViewModel(() => null!, clipLoader: _ => clips);
-        vm.LoadClips(new[] { "root" });
+        await vm.LoadClipsAsync(new[] { "root" });
 
         vm.FilterText = clips[0].FullPath;
 
@@ -315,11 +315,11 @@ public sealed class MainWindowViewModelTests
     }
 
     [Fact]
-    public void FilteredClips_NoMatch_IsEmpty()
+    public async Task FilteredClips_NoMatch_IsEmpty()
     {
         var clips = TestClips.Create(3);
         var vm = new MainWindowViewModel(() => null!, clipLoader: _ => clips);
-        vm.LoadClips(new[] { "root" });
+        await vm.LoadClipsAsync(new[] { "root" });
 
         vm.FilterText = "no-such-clip";
 
@@ -410,8 +410,8 @@ public sealed class MainWindowViewModelTests
     [Fact]
     public void CanGoNextPrevious_ReflectControllerPlaylist()
     {
-        var vm = CreateViewModelWithController(out _, out _, clipLoader: _ => TestClips.Create(3));
-        vm.LoadClips(new[] { "root" });
+        var vm = CreateViewModelWithController(out var controller, out _);
+        controller.LoadClips(TestClips.Create(3)); // set the playlist directly (synchronous, on the test thread)
 
         // Playlist loaded, nothing playing yet: can advance, can't go back.
         vm.CanGoNext.ShouldBeTrue();

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -113,44 +113,14 @@
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="6"
-                                RenderTransformOrigin="0.5,0.5">
-                            <Border.RenderTransform>
-                                <ScaleTransform />
-                            </Border.RenderTransform>
+                                CornerRadius="6">
                             <ContentPresenter />
                         </Border>
                         <ControlTemplate.Triggers>
+                            <!--  No scale animation here: these tiles host the live mini-camera previews, and the
+                                  Flyleaf surface follows the tile's render transform, so scaling would shift the video.  -->
                             <Trigger Property="IsMouseOver" Value="True">
                                 <Setter TargetName="TileBorder" Property="Background" Value="{DynamicResource ControlFillColorSecondaryBrush}" />
-                                <Trigger.EnterActions>
-                                    <BeginStoryboard>
-                                        <Storyboard>
-                                            <DoubleAnimation Storyboard.TargetName="TileBorder"
-                                                             Storyboard.TargetProperty="RenderTransform.ScaleX"
-                                                             To="1.03"
-                                                             Duration="0:0:0.12" />
-                                            <DoubleAnimation Storyboard.TargetName="TileBorder"
-                                                             Storyboard.TargetProperty="RenderTransform.ScaleY"
-                                                             To="1.03"
-                                                             Duration="0:0:0.12" />
-                                        </Storyboard>
-                                    </BeginStoryboard>
-                                </Trigger.EnterActions>
-                                <Trigger.ExitActions>
-                                    <BeginStoryboard>
-                                        <Storyboard>
-                                            <DoubleAnimation Storyboard.TargetName="TileBorder"
-                                                             Storyboard.TargetProperty="RenderTransform.ScaleX"
-                                                             To="1"
-                                                             Duration="0:0:0.15" />
-                                            <DoubleAnimation Storyboard.TargetName="TileBorder"
-                                                             Storyboard.TargetProperty="RenderTransform.ScaleY"
-                                                             To="1"
-                                                             Duration="0:0:0.15" />
-                                        </Storyboard>
-                                    </BeginStoryboard>
-                                </Trigger.ExitActions>
                             </Trigger>
                             <Trigger Property="IsChecked" Value="True">
                                 <Setter TargetName="TileBorder" Property="Background" Value="{DynamicResource ControlFillColorSecondaryBrush}" />
@@ -394,6 +364,16 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
+
+                <!--  Subtle animated loading bar shown while the clip list is (re)scanned  -->
+                <ProgressBar Grid.Row="1"
+                             Height="3"
+                             Margin="4,0"
+                             VerticalAlignment="Top"
+                             Background="Transparent"
+                             BorderThickness="0"
+                             IsIndeterminate="True"
+                             Visibility="{Binding IsLoadingClips, Converter={local:BoolToVisibilityConverter}}" />
 
                 <!--  Folder picker  -->
                 <StackPanel Grid.Row="2"

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -30,9 +30,14 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
-                        <Border Padding="{TemplateBinding Padding}"
+                        <Border x:Name="ButtonBorder"
+                                Padding="{TemplateBinding Padding}"
                                 Background="{TemplateBinding Background}"
-                                CornerRadius="4">
+                                CornerRadius="4"
+                                RenderTransformOrigin="0.5,0.5">
+                            <Border.RenderTransform>
+                                <ScaleTransform />
+                            </Border.RenderTransform>
                             <ContentPresenter HorizontalAlignment="Center"
                                               VerticalAlignment="Center" />
                         </Border>
@@ -42,6 +47,34 @@
                             </Trigger>
                             <Trigger Property="IsPressed" Value="True">
                                 <Setter Property="Background" Value="{DynamicResource ControlFillColorTertiaryBrush}" />
+                                <Trigger.EnterActions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetName="ButtonBorder"
+                                                             Storyboard.TargetProperty="RenderTransform.ScaleX"
+                                                             To="0.96"
+                                                             Duration="0:0:0.08" />
+                                            <DoubleAnimation Storyboard.TargetName="ButtonBorder"
+                                                             Storyboard.TargetProperty="RenderTransform.ScaleY"
+                                                             To="0.96"
+                                                             Duration="0:0:0.08" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </Trigger.EnterActions>
+                                <Trigger.ExitActions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetName="ButtonBorder"
+                                                             Storyboard.TargetProperty="RenderTransform.ScaleX"
+                                                             To="1"
+                                                             Duration="0:0:0.12" />
+                                            <DoubleAnimation Storyboard.TargetName="ButtonBorder"
+                                                             Storyboard.TargetProperty="RenderTransform.ScaleY"
+                                                             To="1"
+                                                             Duration="0:0:0.12" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </Trigger.ExitActions>
                             </Trigger>
                             <Trigger Property="IsEnabled" Value="False">
                                 <Setter Property="Background" Value="{DynamicResource ControlFillColorDisabledBrush}" />
@@ -80,12 +113,44 @@
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="6">
+                                CornerRadius="6"
+                                RenderTransformOrigin="0.5,0.5">
+                            <Border.RenderTransform>
+                                <ScaleTransform />
+                            </Border.RenderTransform>
                             <ContentPresenter />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
                                 <Setter TargetName="TileBorder" Property="Background" Value="{DynamicResource ControlFillColorSecondaryBrush}" />
+                                <Trigger.EnterActions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetName="TileBorder"
+                                                             Storyboard.TargetProperty="RenderTransform.ScaleX"
+                                                             To="1.03"
+                                                             Duration="0:0:0.12" />
+                                            <DoubleAnimation Storyboard.TargetName="TileBorder"
+                                                             Storyboard.TargetProperty="RenderTransform.ScaleY"
+                                                             To="1.03"
+                                                             Duration="0:0:0.12" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </Trigger.EnterActions>
+                                <Trigger.ExitActions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetName="TileBorder"
+                                                             Storyboard.TargetProperty="RenderTransform.ScaleX"
+                                                             To="1"
+                                                             Duration="0:0:0.15" />
+                                            <DoubleAnimation Storyboard.TargetName="TileBorder"
+                                                             Storyboard.TargetProperty="RenderTransform.ScaleY"
+                                                             To="1"
+                                                             Duration="0:0:0.15" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </Trigger.ExitActions>
                             </Trigger>
                             <Trigger Property="IsChecked" Value="True">
                                 <Setter TargetName="TileBorder" Property="Background" Value="{DynamicResource ControlFillColorSecondaryBrush}" />
@@ -147,6 +212,24 @@
         </Style>
     </Window.Resources>
 
+    <Window.Triggers>
+        <!--  Fade the window in on launch  -->
+        <EventTrigger RoutedEvent="Loaded">
+            <BeginStoryboard>
+                <Storyboard>
+                    <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                     From="0"
+                                     To="1"
+                                     Duration="0:0:0.25">
+                        <DoubleAnimation.EasingFunction>
+                            <CubicEase EasingMode="EaseOut" />
+                        </DoubleAnimation.EasingFunction>
+                    </DoubleAnimation>
+                </Storyboard>
+            </BeginStoryboard>
+        </EventTrigger>
+    </Window.Triggers>
+
     <Grid>
         <Grid Visibility="{Binding ShowMainContent, Converter={local:BoolToVisibilityConverter}}">
             <Grid.ColumnDefinitions>
@@ -204,9 +287,26 @@
                          Margin="4,0"
                          Background="Transparent"
                          BorderThickness="0"
-                         ItemsSource="{Binding FilteredClips}"
+                         ItemsSource="{Binding FilteredClips, NotifyOnTargetUpdated=True}"
                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                          SelectedItem="{Binding SelectedClip, Mode=TwoWay}">
+                    <ListBox.Triggers>
+                        <!--  Fade the list in when its contents change (load or filter) — not on scroll  -->
+                        <EventTrigger RoutedEvent="Binding.TargetUpdated">
+                            <BeginStoryboard>
+                                <Storyboard>
+                                    <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                     From="0"
+                                                     To="1"
+                                                     Duration="0:0:0.2">
+                                        <DoubleAnimation.EasingFunction>
+                                            <CubicEase EasingMode="EaseOut" />
+                                        </DoubleAnimation.EasingFunction>
+                                    </DoubleAnimation>
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </EventTrigger>
+                    </ListBox.Triggers>
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem">
                             <Setter Property="Padding" Value="8" />
@@ -655,6 +755,29 @@
                     <Border Grid.RowSpan="2"
                             Background="#80000000"
                             Visibility="{Binding ShowStatusOverlay, Converter={local:BoolToVisibilityConverter}}">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ShowStatusOverlay}"
+                                                 Value="True">
+                                        <DataTrigger.EnterActions>
+                                            <BeginStoryboard>
+                                                <Storyboard>
+                                                    <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                                     From="0"
+                                                                     To="1"
+                                                                     Duration="0:0:0.2">
+                                                        <DoubleAnimation.EasingFunction>
+                                                            <CubicEase EasingMode="EaseOut" />
+                                                        </DoubleAnimation.EasingFunction>
+                                                    </DoubleAnimation>
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </DataTrigger.EnterActions>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
                         <StackPanel MaxWidth="500"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center">
@@ -822,6 +945,29 @@
 
         <Grid Background="{DynamicResource SystemFillColorSolidNeutralBackgroundBrush}"
               Visibility="{Binding ShowAboutPage, Converter={local:BoolToVisibilityConverter}}">
+            <Grid.Style>
+                <Style TargetType="Grid">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ShowAboutPage}"
+                                     Value="True">
+                            <DataTrigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                         From="0"
+                                                         To="1"
+                                                         Duration="0:0:0.22">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut" />
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </DataTrigger.EnterActions>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Style>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -443,10 +443,35 @@
 
                     <Grid x:Name="FlyleafHostPool"
                           Visibility="Collapsed">
-                        <fl:FlyleafHost x:Name="FrontFlyleafHost" />
-                        <fl:FlyleafHost x:Name="BackFlyleafHost" />
-                        <fl:FlyleafHost x:Name="LeftFlyleafHost" />
-                        <fl:FlyleafHost x:Name="RightFlyleafHost" />
+                        <!--
+                            Each host carries an opaque cover as FlyleafHost overlay content (rendered above the
+                            video surface, beating WPF airspace). It hides the player's first-frame load-in and is
+                            faded out from code-behind once the clip is ready. See MainWindow.UpdateVideoCovers.
+                        -->
+                        <fl:FlyleafHost x:Name="FrontFlyleafHost">
+                            <Border x:Name="FrontVideoCover"
+                                    Background="Black"
+                                    IsHitTestVisible="False"
+                                    Opacity="0" />
+                        </fl:FlyleafHost>
+                        <fl:FlyleafHost x:Name="BackFlyleafHost">
+                            <Border x:Name="BackVideoCover"
+                                    Background="Black"
+                                    IsHitTestVisible="False"
+                                    Opacity="0" />
+                        </fl:FlyleafHost>
+                        <fl:FlyleafHost x:Name="LeftFlyleafHost">
+                            <Border x:Name="LeftVideoCover"
+                                    Background="Black"
+                                    IsHitTestVisible="False"
+                                    Opacity="0" />
+                        </fl:FlyleafHost>
+                        <fl:FlyleafHost x:Name="RightFlyleafHost">
+                            <Border x:Name="RightVideoCover"
+                                    Background="Black"
+                                    IsHitTestVisible="False"
+                                    Opacity="0" />
+                        </fl:FlyleafHost>
                     </Grid>
 
                     <!--  Video Player  -->

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -257,26 +257,9 @@
                          Margin="4,0"
                          Background="Transparent"
                          BorderThickness="0"
-                         ItemsSource="{Binding FilteredClips, NotifyOnTargetUpdated=True}"
+                         ItemsSource="{Binding FilteredClips}"
                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                          SelectedItem="{Binding SelectedClip, Mode=TwoWay}">
-                    <ListBox.Triggers>
-                        <!--  Fade the list in when its contents change (load or filter) — not on scroll  -->
-                        <EventTrigger RoutedEvent="Binding.TargetUpdated">
-                            <BeginStoryboard>
-                                <Storyboard>
-                                    <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                                     From="0"
-                                                     To="1"
-                                                     Duration="0:0:0.2">
-                                        <DoubleAnimation.EasingFunction>
-                                            <CubicEase EasingMode="EaseOut" />
-                                        </DoubleAnimation.EasingFunction>
-                                    </DoubleAnimation>
-                                </Storyboard>
-                            </BeginStoryboard>
-                        </EventTrigger>
-                    </ListBox.Triggers>
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem">
                             <Setter Property="Padding" Value="8" />
@@ -378,10 +361,23 @@
                 <!--  Folder picker  -->
                 <StackPanel Grid.Row="2"
                             Margin="8">
-                    <Button Content="📁 Select Folder"
-                            Command="{Binding OpenFolderCommand}"
-                            Padding="12"
-                            Style="{StaticResource PlayerButton}" />
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Button Grid.Column="0"
+                                Content="📁 Select Folder"
+                                Command="{Binding OpenFolderCommand}"
+                                Padding="12"
+                                Style="{StaticResource PlayerButton}" />
+                        <Button Grid.Column="1"
+                                Content="🔄"
+                                Command="{Binding RefreshClipsCommand}"
+                                Padding="12"
+                                Style="{StaticResource PlayerButton}"
+                                ToolTip="Rescan the current folder for clips" />
+                    </Grid>
                     <Grid Margin="0,8,0,0">
                         <Button Content="ℹ️ About / Help"
                                 Command="{Binding ToggleAboutCommand}"
@@ -612,12 +608,11 @@
                                                 CornerRadius="4">
                                             <Grid>
                                                 <ContentControl x:Name="FrontTileHostSlot" />
-                                                <TextBlock Text="Main view"
-                                                           HorizontalAlignment="Center"
-                                                           VerticalAlignment="Center"
-                                                           FontSize="12"
-                                                           Foreground="{DynamicResource TextControlPlaceholderForeground}"
-                                                           Visibility="{Binding IsFrontViewSelected, Converter={local:BoolToVisibilityConverter}}" />
+                                                <!--  Single-screen icon: this camera is the main view (cf. the 2x2 grid icon)  -->
+                                                <Border Margin="18"
+                                                        Background="{DynamicResource ControlFillColorSecondaryBrush}"
+                                                        CornerRadius="3"
+                                                        Visibility="{Binding IsFrontViewSelected, Converter={local:BoolToVisibilityConverter}}" />
                                             </Grid>
                                         </Border>
                                         <TextBlock Grid.Row="1"
@@ -645,12 +640,11 @@
                                                 CornerRadius="4">
                                             <Grid>
                                                 <ContentControl x:Name="RearTileHostSlot" />
-                                                <TextBlock Text="Main view"
-                                                           HorizontalAlignment="Center"
-                                                           VerticalAlignment="Center"
-                                                           FontSize="12"
-                                                           Foreground="{DynamicResource TextControlPlaceholderForeground}"
-                                                           Visibility="{Binding IsRearViewSelected, Converter={local:BoolToVisibilityConverter}}" />
+                                                <!--  Single-screen icon: this camera is the main view (cf. the 2x2 grid icon)  -->
+                                                <Border Margin="18"
+                                                        Background="{DynamicResource ControlFillColorSecondaryBrush}"
+                                                        CornerRadius="3"
+                                                        Visibility="{Binding IsRearViewSelected, Converter={local:BoolToVisibilityConverter}}" />
                                             </Grid>
                                         </Border>
                                         <TextBlock Grid.Row="1"
@@ -678,12 +672,11 @@
                                                 CornerRadius="4">
                                             <Grid>
                                                 <ContentControl x:Name="LeftTileHostSlot" />
-                                                <TextBlock Text="Main view"
-                                                           HorizontalAlignment="Center"
-                                                           VerticalAlignment="Center"
-                                                           FontSize="12"
-                                                           Foreground="{DynamicResource TextControlPlaceholderForeground}"
-                                                           Visibility="{Binding IsLeftViewSelected, Converter={local:BoolToVisibilityConverter}}" />
+                                                <!--  Single-screen icon: this camera is the main view (cf. the 2x2 grid icon)  -->
+                                                <Border Margin="18"
+                                                        Background="{DynamicResource ControlFillColorSecondaryBrush}"
+                                                        CornerRadius="3"
+                                                        Visibility="{Binding IsLeftViewSelected, Converter={local:BoolToVisibilityConverter}}" />
                                             </Grid>
                                         </Border>
                                         <TextBlock Grid.Row="1"
@@ -711,12 +704,11 @@
                                                 CornerRadius="4">
                                             <Grid>
                                                 <ContentControl x:Name="RightTileHostSlot" />
-                                                <TextBlock Text="Main view"
-                                                           HorizontalAlignment="Center"
-                                                           VerticalAlignment="Center"
-                                                           FontSize="12"
-                                                           Foreground="{DynamicResource TextControlPlaceholderForeground}"
-                                                           Visibility="{Binding IsRightViewSelected, Converter={local:BoolToVisibilityConverter}}" />
+                                                <!--  Single-screen icon: this camera is the main view (cf. the 2x2 grid icon)  -->
+                                                <Border Margin="18"
+                                                        Background="{DynamicResource ControlFillColorSecondaryBrush}"
+                                                        CornerRadius="3"
+                                                        Visibility="{Binding IsRightViewSelected, Converter={local:BoolToVisibilityConverter}}" />
                                             </Grid>
                                         </Border>
                                         <TextBlock Grid.Row="1"
@@ -925,29 +917,6 @@
 
         <Grid Background="{DynamicResource SystemFillColorSolidNeutralBackgroundBrush}"
               Visibility="{Binding ShowAboutPage, Converter={local:BoolToVisibilityConverter}}">
-            <Grid.Style>
-                <Style TargetType="Grid">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding ShowAboutPage}"
-                                     Value="True">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                                         From="0"
-                                                         To="1"
-                                                         Duration="0:0:0.22">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CubicEase EasingMode="EaseOut" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </DataTrigger.EnterActions>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Grid.Style>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -443,35 +443,10 @@
 
                     <Grid x:Name="FlyleafHostPool"
                           Visibility="Collapsed">
-                        <!--
-                            Each host carries an opaque cover as FlyleafHost overlay content (rendered above the
-                            video surface, beating WPF airspace). It hides the player's first-frame load-in and is
-                            faded out from code-behind once the clip is ready. See MainWindow.UpdateVideoCovers.
-                        -->
-                        <fl:FlyleafHost x:Name="FrontFlyleafHost">
-                            <Border x:Name="FrontVideoCover"
-                                    Background="Black"
-                                    IsHitTestVisible="False"
-                                    Opacity="0" />
-                        </fl:FlyleafHost>
-                        <fl:FlyleafHost x:Name="BackFlyleafHost">
-                            <Border x:Name="BackVideoCover"
-                                    Background="Black"
-                                    IsHitTestVisible="False"
-                                    Opacity="0" />
-                        </fl:FlyleafHost>
-                        <fl:FlyleafHost x:Name="LeftFlyleafHost">
-                            <Border x:Name="LeftVideoCover"
-                                    Background="Black"
-                                    IsHitTestVisible="False"
-                                    Opacity="0" />
-                        </fl:FlyleafHost>
-                        <fl:FlyleafHost x:Name="RightFlyleafHost">
-                            <Border x:Name="RightVideoCover"
-                                    Background="Black"
-                                    IsHitTestVisible="False"
-                                    Opacity="0" />
-                        </fl:FlyleafHost>
+                        <fl:FlyleafHost x:Name="FrontFlyleafHost" />
+                        <fl:FlyleafHost x:Name="BackFlyleafHost" />
+                        <fl:FlyleafHost x:Name="LeftFlyleafHost" />
+                        <fl:FlyleafHost x:Name="RightFlyleafHost" />
                     </Grid>
 
                     <!--  Video Player  -->

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media.Animation;
 using System.Windows.Navigation;
 using FlyleafLib.Controls.WPF;
 using Serilog;
@@ -102,30 +101,9 @@ public partial class MainWindow : Window
 
     private void ViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
-        switch (e.PropertyName)
+        if (e.PropertyName == nameof(MainWindowViewModel.SelectedCameraView))
         {
-            case nameof(MainWindowViewModel.SelectedCameraView):
-                UpdateCameraHostLayout();
-                break;
-
-            case nameof(MainWindowViewModel.IsLoading):
-                UpdateVideoCovers(_viewModel.IsLoading);
-                break;
-        }
-    }
-
-    // Fades the per-host covers (FlyleafHost overlay content) so the player's first-frame load-in happens
-    // behind an opaque cover, then reveals the ready frame. Covers snap on quickly and reveal gently.
-    private void UpdateVideoCovers(bool covered)
-    {
-        var animation = new DoubleAnimation(covered ? 1.0 : 0.0, new Duration(TimeSpan.FromMilliseconds(covered ? 60 : 280)))
-        {
-            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
-        };
-
-        foreach (var cover in new[] { FrontVideoCover, BackVideoCover, LeftVideoCover, RightVideoCover })
-        {
-            cover.BeginAnimation(OpacityProperty, animation);
+            UpdateCameraHostLayout();
         }
     }
 

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -118,8 +118,6 @@ public partial class MainWindow : Window
         if (PrimaryCameraHostSlot is null)
             return;
 
-        ClearCameraHostSlots();
-
         switch (_viewModel.SelectedCameraView)
         {
             case MainWindowViewModel.GridCameraView:
@@ -157,30 +155,11 @@ public partial class MainWindow : Window
                 MoveHostToSlot(RightFlyleafHost, RightTileHostSlot);
                 break;
         }
-    }
 
-    private void ClearCameraHostSlots()
-    {
-        ContentControl[] slots =
-        [
-            PrimaryCameraHostSlot,
-            GridFrontHostSlot,
-            GridRearHostSlot,
-            GridLeftHostSlot,
-            GridRightHostSlot,
-            FrontTileHostSlot,
-            RearTileHostSlot,
-            LeftTileHostSlot,
-            RightTileHostSlot,
-        ];
-
-        foreach (var slot in slots)
-        {
-            if (slot.Content is FlyleafHost)
-            {
-                slot.Content = null;
-            }
-        }
+        // Force a synchronous layout pass so each moved host gets its final bounds before the next render
+        // frame. The Flyleaf surface follows the host via its LayoutUpdated event, so without this it would
+        // briefly render at a stale/default rect (a small player flashing in the top-left) before snapping.
+        UpdateLayout();
     }
 
     private static void MoveHostToSlot(FlyleafHost host, ContentControl slot)

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -118,32 +118,15 @@ public partial class MainWindow : Window
         if (PrimaryCameraHostSlot is null)
             return;
 
-        var layout = GetCameraHostLayout(_viewModel.SelectedCameraView);
-
-        // Hide every host that's about to move BEFORE reparenting it. A FlyleafHost's native surface is
-        // hidden while the control isn't visible, so this keeps the surface from briefly painting at its
-        // default position (a small player flashing in the top-left) while the new slot is laid out.
-        foreach (var (host, slot) in layout)
-        {
-            if (!ReferenceEquals(slot.Content, host))
-            {
-                host.Visibility = Visibility.Hidden;
-            }
-        }
-
-        foreach (var (host, slot) in layout)
+        foreach (var (host, slot) in GetCameraHostLayout(_viewModel.SelectedCameraView))
         {
             MoveHostToSlot(host, slot);
         }
 
-        // Lay the moved hosts out (which repositions their hidden surfaces) before showing them again,
-        // so each surface only ever appears at its final slot bounds.
+        // Force a synchronous layout pass so each moved host reaches its final bounds promptly. Note: a
+        // brief flash of the reparented Flyleaf surface at its old size is a known limitation here and is
+        // accepted (eliminating it would require not reparenting the hosts at all).
         UpdateLayout();
-
-        foreach (var (host, _) in layout)
-        {
-            host.Visibility = Visibility.Visible;
-        }
     }
 
     private IReadOnlyList<(FlyleafHost Host, ContentControl Slot)> GetCameraHostLayout(string view) => view switch

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -118,49 +118,72 @@ public partial class MainWindow : Window
         if (PrimaryCameraHostSlot is null)
             return;
 
-        switch (_viewModel.SelectedCameraView)
+        var layout = GetCameraHostLayout(_viewModel.SelectedCameraView);
+
+        // Hide every host that's about to move BEFORE reparenting it. A FlyleafHost's native surface is
+        // hidden while the control isn't visible, so this keeps the surface from briefly painting at its
+        // default position (a small player flashing in the top-left) while the new slot is laid out.
+        foreach (var (host, slot) in layout)
         {
-            case MainWindowViewModel.GridCameraView:
-                MoveHostToSlot(FrontFlyleafHost, GridFrontHostSlot);
-                MoveHostToSlot(BackFlyleafHost, GridRearHostSlot);
-                MoveHostToSlot(LeftFlyleafHost, GridLeftHostSlot);
-                MoveHostToSlot(RightFlyleafHost, GridRightHostSlot);
-                break;
-
-            case MainWindowViewModel.RearCameraView:
-                MoveHostToSlot(BackFlyleafHost, PrimaryCameraHostSlot);
-                MoveHostToSlot(FrontFlyleafHost, FrontTileHostSlot);
-                MoveHostToSlot(LeftFlyleafHost, LeftTileHostSlot);
-                MoveHostToSlot(RightFlyleafHost, RightTileHostSlot);
-                break;
-
-            case MainWindowViewModel.LeftCameraView:
-                MoveHostToSlot(LeftFlyleafHost, PrimaryCameraHostSlot);
-                MoveHostToSlot(FrontFlyleafHost, FrontTileHostSlot);
-                MoveHostToSlot(BackFlyleafHost, RearTileHostSlot);
-                MoveHostToSlot(RightFlyleafHost, RightTileHostSlot);
-                break;
-
-            case MainWindowViewModel.RightCameraView:
-                MoveHostToSlot(RightFlyleafHost, PrimaryCameraHostSlot);
-                MoveHostToSlot(FrontFlyleafHost, FrontTileHostSlot);
-                MoveHostToSlot(BackFlyleafHost, RearTileHostSlot);
-                MoveHostToSlot(LeftFlyleafHost, LeftTileHostSlot);
-                break;
-
-            default:
-                MoveHostToSlot(FrontFlyleafHost, PrimaryCameraHostSlot);
-                MoveHostToSlot(BackFlyleafHost, RearTileHostSlot);
-                MoveHostToSlot(LeftFlyleafHost, LeftTileHostSlot);
-                MoveHostToSlot(RightFlyleafHost, RightTileHostSlot);
-                break;
+            if (!ReferenceEquals(slot.Content, host))
+            {
+                host.Visibility = Visibility.Hidden;
+            }
         }
 
-        // Force a synchronous layout pass so each moved host gets its final bounds before the next render
-        // frame. The Flyleaf surface follows the host via its LayoutUpdated event, so without this it would
-        // briefly render at a stale/default rect (a small player flashing in the top-left) before snapping.
+        foreach (var (host, slot) in layout)
+        {
+            MoveHostToSlot(host, slot);
+        }
+
+        // Lay the moved hosts out (which repositions their hidden surfaces) before showing them again,
+        // so each surface only ever appears at its final slot bounds.
         UpdateLayout();
+
+        foreach (var (host, _) in layout)
+        {
+            host.Visibility = Visibility.Visible;
+        }
     }
+
+    private IReadOnlyList<(FlyleafHost Host, ContentControl Slot)> GetCameraHostLayout(string view) => view switch
+    {
+        MainWindowViewModel.GridCameraView =>
+        [
+            (FrontFlyleafHost, GridFrontHostSlot),
+            (BackFlyleafHost, GridRearHostSlot),
+            (LeftFlyleafHost, GridLeftHostSlot),
+            (RightFlyleafHost, GridRightHostSlot),
+        ],
+        MainWindowViewModel.RearCameraView =>
+        [
+            (BackFlyleafHost, PrimaryCameraHostSlot),
+            (FrontFlyleafHost, FrontTileHostSlot),
+            (LeftFlyleafHost, LeftTileHostSlot),
+            (RightFlyleafHost, RightTileHostSlot),
+        ],
+        MainWindowViewModel.LeftCameraView =>
+        [
+            (LeftFlyleafHost, PrimaryCameraHostSlot),
+            (FrontFlyleafHost, FrontTileHostSlot),
+            (BackFlyleafHost, RearTileHostSlot),
+            (RightFlyleafHost, RightTileHostSlot),
+        ],
+        MainWindowViewModel.RightCameraView =>
+        [
+            (RightFlyleafHost, PrimaryCameraHostSlot),
+            (FrontFlyleafHost, FrontTileHostSlot),
+            (BackFlyleafHost, RearTileHostSlot),
+            (LeftFlyleafHost, LeftTileHostSlot),
+        ],
+        _ =>
+        [
+            (FrontFlyleafHost, PrimaryCameraHostSlot),
+            (BackFlyleafHost, RearTileHostSlot),
+            (LeftFlyleafHost, LeftTileHostSlot),
+            (RightFlyleafHost, RightTileHostSlot),
+        ],
+    };
 
     private static void MoveHostToSlot(FlyleafHost host, ContentControl slot)
     {

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media.Animation;
 using System.Windows.Navigation;
 using FlyleafLib.Controls.WPF;
 using Serilog;
@@ -101,9 +102,30 @@ public partial class MainWindow : Window
 
     private void ViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(MainWindowViewModel.SelectedCameraView))
+        switch (e.PropertyName)
         {
-            UpdateCameraHostLayout();
+            case nameof(MainWindowViewModel.SelectedCameraView):
+                UpdateCameraHostLayout();
+                break;
+
+            case nameof(MainWindowViewModel.IsLoading):
+                UpdateVideoCovers(_viewModel.IsLoading);
+                break;
+        }
+    }
+
+    // Fades the per-host covers (FlyleafHost overlay content) so the player's first-frame load-in happens
+    // behind an opaque cover, then reveals the ready frame. Covers snap on quickly and reveal gently.
+    private void UpdateVideoCovers(bool covered)
+    {
+        var animation = new DoubleAnimation(covered ? 1.0 : 0.0, new Duration(TimeSpan.FromMilliseconds(covered ? 60 : 280)))
+        {
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+        };
+
+        foreach (var cover in new[] { FrontVideoCover, BackVideoCover, LeftVideoCover, RightVideoCover })
+        {
+            cover.BeginAnimation(OpacityProperty, animation);
         }
     }
 

--- a/SentryReplay/MainWindowViewModel.cs
+++ b/SentryReplay/MainWindowViewModel.cs
@@ -130,9 +130,9 @@ public partial class MainWindowViewModel : ObservableObject
 
     public string PlayPauseIcon => IsPlaying ? "⏸" : "▶";
 
-    // The full-screen WPF overlay only covers the no-video states (scanning with no clip, error, empty),
-    // because as a WPF sibling it can't draw over the Flyleaf surface anyway. A selected clip's own load is
-    // hidden by the per-host covers (FlyleafHost overlay content) instead, so the hosts stay visible.
+    // The full-screen overlay only covers the no-video states (scanning with no clip, error, empty); as a WPF
+    // sibling it can't draw over the Flyleaf video surface anyway. While a selected clip loads, the hosts stay
+    // visible and simply show black until the first frame decodes — no loading screen flashing mid-playback.
     public bool ShowStatusOverlay => (IsLoading && SelectedClip is null) || ShowErrorOverlay || HasNoClipSelected;
 
     public bool ShowVideoHosts => SelectedClip is not null && !ShowErrorOverlay;

--- a/SentryReplay/MainWindowViewModel.cs
+++ b/SentryReplay/MainWindowViewModel.cs
@@ -38,6 +38,10 @@ public partial class MainWindowViewModel : ObservableObject
     private bool _isSeeking;
     private bool _isInitialized;
 
+    // The source of dashcam roots: auto-discovery by default, or the user's last picked folders. Refresh
+    // re-evaluates it to rescan for newly added clips (and, for auto-discovery, newly connected drives).
+    private Func<IEnumerable<string>> _rootSource = CamStorage.FindCommonRoots;
+
     /// <param name="playerControllerFactory">Creates the playback controller (the view supplies one bound to its Flyleaf hosts).</param>
     /// <param name="clipLoader">Maps a dashcam root to its clips. Defaults to scanning the filesystem; overridable for tests.</param>
     /// <param name="backgroundYield">Yields to the UI before a clip loads so the window stays responsive. Overridable for tests.</param>
@@ -222,6 +226,7 @@ public partial class MainWindowViewModel : ObservableObject
 
     // True while the clip list is being (re)scanned from disk; drives the sidebar loading indicator.
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RefreshClipsCommand))]
     private bool _isLoadingClips;
 
     [ObservableProperty]
@@ -281,7 +286,7 @@ public partial class MainWindowViewModel : ObservableObject
         if (_flyleafRuntime.TryStart())
         {
             InitializePlayer();
-            await LoadClipsAsync(CamStorage.FindCommonRoots());
+            await LoadClipsAsync(_rootSource());
         }
         else
         {
@@ -433,23 +438,40 @@ public partial class MainWindowViewModel : ObservableObject
 
         if (dialog.ShowDialog() == true)
         {
+            var folders = dialog.FolderNames;
             Log.Information(
                 "User selected dashcam folders. FolderCount={FolderCount}; Folders={Folders}",
-                dialog.FolderNames.Length,
-                dialog.FolderNames);
+                folders.Length,
+                folders);
 
             if (_playerController is not null)
             {
                 await _playerController.StopAsync();
             }
 
-            await LoadClipsAsync(dialog.FolderNames);
+            _rootSource = () => folders;
+            await LoadClipsAsync(folders);
         }
         else
         {
             Log.Debug("Folder picker canceled");
         }
     }
+
+    [RelayCommand(CanExecute = nameof(CanRefreshClips))]
+    private async Task RefreshClipsAsync()
+    {
+        Log.Debug("Refreshing clips");
+
+        if (_playerController is not null)
+        {
+            await _playerController.StopAsync();
+        }
+
+        await LoadClipsAsync(_rootSource());
+    }
+
+    private bool CanRefreshClips => !IsLoadingClips;
 
     [RelayCommand]
     private async Task PlayPauseAsync()
@@ -503,7 +525,7 @@ public partial class MainWindowViewModel : ObservableObject
             if (_flyleafRuntime.TryStart())
             {
                 InitializePlayer();
-                await LoadClipsAsync(CamStorage.FindCommonRoots());
+                await LoadClipsAsync(_rootSource());
             }
             else
             {

--- a/SentryReplay/MainWindowViewModel.cs
+++ b/SentryReplay/MainWindowViewModel.cs
@@ -339,6 +339,7 @@ public partial class MainWindowViewModel : ObservableObject
         finally
         {
             IsLoading = false;
+            OnPropertyChanged(nameof(FilteredClips));
             RefreshClipState();
         }
     }
@@ -399,7 +400,9 @@ public partial class MainWindowViewModel : ObservableObject
 
     private void RefreshClipState()
     {
-        OnPropertyChanged(nameof(FilteredClips));
+        // FilteredClips is intentionally NOT raised here: this runs on every clip change, and
+        // re-notifying the unchanged list rebuilds the ListBox and retriggers its fade (flicker).
+        // The list is notified explicitly only when it actually changes (load + FilterText).
         OnPropertyChanged(nameof(HasNoClipSelected));
         OnPropertyChanged(nameof(ShowStatusOverlay));
         OnPropertyChanged(nameof(ShowVideoHosts));

--- a/SentryReplay/MainWindowViewModel.cs
+++ b/SentryReplay/MainWindowViewModel.cs
@@ -220,6 +220,10 @@ public partial class MainWindowViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(IsIndeterminateProgress))]
     private bool _isRendering;
 
+    // True while the clip list is being (re)scanned from disk; drives the sidebar loading indicator.
+    [ObservableProperty]
+    private bool _isLoadingClips;
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(RenderProgressPercent))]
     [NotifyPropertyChangedFor(nameof(LoadingStatusText))]
@@ -313,6 +317,7 @@ public partial class MainWindowViewModel : ObservableObject
         _allClips.Clear();
         SelectedClip = null;
         IsLoading = true;
+        IsLoadingClips = true;
         RefreshClipState();
 
         try
@@ -342,6 +347,7 @@ public partial class MainWindowViewModel : ObservableObject
         finally
         {
             IsLoading = false;
+            IsLoadingClips = false;
             OnPropertyChanged(nameof(FilteredClips));
             RefreshClipState();
         }

--- a/SentryReplay/MainWindowViewModel.cs
+++ b/SentryReplay/MainWindowViewModel.cs
@@ -316,14 +316,19 @@ public partial class MainWindowViewModel : ObservableObject
         _playerController.PlaybackSpeed = SelectedPlaybackSpeed;
     }
 
-    public async Task LoadClipsAsync(IEnumerable<string> roots)
+    public async Task LoadClipsAsync(IEnumerable<string> roots, TimeSpan minimumLoadingDuration = default)
     {
         ClearError();
         _allClips.Clear();
         SelectedClip = null;
         IsLoading = true;
         IsLoadingClips = true;
+
+        // Clear the list right away so a (re)scan visibly empties it and shows the loading bar before refilling.
+        OnPropertyChanged(nameof(FilteredClips));
         RefreshClipState();
+
+        var stopwatch = Stopwatch.StartNew();
 
         try
         {
@@ -348,6 +353,14 @@ public partial class MainWindowViewModel : ObservableObject
             }
 
             _playerController?.LoadClips(_allClips);
+
+            // Hold the loading state briefly so a fast rescan still reads as a deliberate refresh
+            // (clear -> loading -> refill) instead of an imperceptible flicker.
+            var remaining = minimumLoadingDuration - stopwatch.Elapsed;
+            if (remaining > TimeSpan.Zero)
+            {
+                await Task.Delay(remaining);
+            }
         }
         finally
         {
@@ -468,7 +481,7 @@ public partial class MainWindowViewModel : ObservableObject
             await _playerController.StopAsync();
         }
 
-        await LoadClipsAsync(_rootSource());
+        await LoadClipsAsync(_rootSource(), TimeSpan.FromMilliseconds(400));
     }
 
     private bool CanRefreshClips => !IsLoadingClips;

--- a/SentryReplay/MainWindowViewModel.cs
+++ b/SentryReplay/MainWindowViewModel.cs
@@ -274,7 +274,7 @@ public partial class MainWindowViewModel : ObservableObject
         if (_flyleafRuntime.TryStart())
         {
             InitializePlayer();
-            LoadClips(CamStorage.FindCommonRoots());
+            await LoadClipsAsync(CamStorage.FindCommonRoots());
         }
         else
         {
@@ -304,27 +304,58 @@ public partial class MainWindowViewModel : ObservableObject
         _playerController.PlaybackSpeed = SelectedPlaybackSpeed;
     }
 
-    public void LoadClips(IEnumerable<string> roots)
+    public async Task LoadClipsAsync(IEnumerable<string> roots)
     {
         ClearError();
         _allClips.Clear();
         SelectedClip = null;
+        IsLoading = true;
+        RefreshClipState();
 
+        try
+        {
+            // Scan the disk off the UI thread; the continuation resumes on it via the WPF
+            // SynchronizationContext, so all view-model state below is mutated on the UI thread.
+            var result = await Task.Run(() => ScanRoots(roots));
+
+            if (!result.HadRoots)
+            {
+                ShowError(
+                    "No Dashcam Folders Found",
+                    "Click 'Select Folder' to choose a folder containing Tesla dashcam footage (TeslaCam folder).",
+                    canDismiss: true);
+            }
+            else
+            {
+                _allClips.AddRange(result.Clips);
+                foreach (var error in result.Errors)
+                {
+                    ShowError(error.Title, error.Details);
+                }
+            }
+
+            _playerController?.LoadClips(_allClips);
+        }
+        finally
+        {
+            IsLoading = false;
+            RefreshClipState();
+        }
+    }
+
+    private ScanResult ScanRoots(IEnumerable<string> roots)
+    {
         var rootList = roots?.Where(root => !string.IsNullOrWhiteSpace(root)).ToList() ?? [];
         if (rootList.Count == 0)
         {
             Log.Information("No dashcam roots found");
-            ShowError(
-                "No Dashcam Folders Found",
-                "Click 'Select Folder' to choose a folder containing Tesla dashcam footage (TeslaCam folder).",
-                canDismiss: true);
-            RefreshClipState();
-            return;
+            return new ScanResult([], [], HadRoots: false);
         }
 
         Log.Information("Loading dashcam clips. RootCount={RootCount}; Roots={Roots}", rootList.Count, rootList);
         var totalStopwatch = Stopwatch.StartNew();
-        var failedRoots = 0;
+        var clips = new List<CamClip>();
+        var errors = new List<ClipLoadError>();
 
         foreach (var root in rootList)
         {
@@ -333,37 +364,38 @@ public partial class MainWindowViewModel : ObservableObject
 
             try
             {
-                var clips = _clipLoader(root);
-                _allClips.AddRange(clips);
+                var rootClips = _clipLoader(root);
+                clips.AddRange(rootClips);
                 Log.Information(
                     "Scanned dashcam root. Root={Root}; ClipCount={ClipCount}; ElapsedMs={ElapsedMs}",
                     root,
-                    clips.Count,
+                    rootClips.Count,
                     rootStopwatch.ElapsedMilliseconds);
             }
             catch (UnauthorizedAccessException ex)
             {
-                failedRoots++;
                 Log.Error(ex, "Access denied while loading dashcam root. Root={Root}", root);
-                ShowError("Access Denied", $"Cannot access folder: {root}\n\nCheck that you have permission to read this location.");
+                errors.Add(new ClipLoadError("Access Denied", $"Cannot access folder: {root}\n\nCheck that you have permission to read this location."));
             }
             catch (Exception ex)
             {
-                failedRoots++;
                 Log.Error(ex, "Failed to load dashcam root. Root={Root}", root);
-                ShowError("Error Loading Clips", $"Failed to load clips from:\n{root}\n\nError: {ex.Message}");
+                errors.Add(new ClipLoadError("Error Loading Clips", $"Failed to load clips from:\n{root}\n\nError: {ex.Message}"));
             }
         }
 
-        _playerController?.LoadClips(_allClips);
-        RefreshClipState();
         Log.Information(
             "Finished loading dashcam clips. ClipCount={ClipCount}; RootCount={RootCount}; FailedRootCount={FailedRootCount}; ElapsedMs={ElapsedMs}",
-            _allClips.Count,
+            clips.Count,
             rootList.Count,
-            failedRoots,
+            errors.Count,
             totalStopwatch.ElapsedMilliseconds);
+        return new ScanResult(clips, errors, HadRoots: true);
     }
+
+    private sealed record ScanResult(IReadOnlyList<CamClip> Clips, IReadOnlyList<ClipLoadError> Errors, bool HadRoots);
+
+    private sealed record ClipLoadError(string Title, string Details);
 
     private void RefreshClipState()
     {
@@ -399,7 +431,7 @@ public partial class MainWindowViewModel : ObservableObject
                 await _playerController.StopAsync();
             }
 
-            LoadClips(dialog.FolderNames);
+            await LoadClipsAsync(dialog.FolderNames);
         }
         else
         {
@@ -459,7 +491,7 @@ public partial class MainWindowViewModel : ObservableObject
             if (_flyleafRuntime.TryStart())
             {
                 InitializePlayer();
-                LoadClips(CamStorage.FindCommonRoots());
+                await LoadClipsAsync(CamStorage.FindCommonRoots());
             }
             else
             {

--- a/SentryReplay/MainWindowViewModel.cs
+++ b/SentryReplay/MainWindowViewModel.cs
@@ -130,9 +130,12 @@ public partial class MainWindowViewModel : ObservableObject
 
     public string PlayPauseIcon => IsPlaying ? "⏸" : "▶";
 
-    public bool ShowStatusOverlay => IsLoading || ShowErrorOverlay || HasNoClipSelected;
+    // The full-screen WPF overlay only covers the no-video states (scanning with no clip, error, empty),
+    // because as a WPF sibling it can't draw over the Flyleaf surface anyway. A selected clip's own load is
+    // hidden by the per-host covers (FlyleafHost overlay content) instead, so the hosts stay visible.
+    public bool ShowStatusOverlay => (IsLoading && SelectedClip is null) || ShowErrorOverlay || HasNoClipSelected;
 
-    public bool ShowVideoHosts => !ShowStatusOverlay;
+    public bool ShowVideoHosts => SelectedClip is not null && !ShowErrorOverlay;
 
     public bool HasError => ShowErrorOverlay;
 

--- a/SentryReplay/Playback/VideoPlayerController.cs
+++ b/SentryReplay/Playback/VideoPlayerController.cs
@@ -387,7 +387,9 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
                     _timeline.Count,
                     Duration,
                     requestId);
-                await OpenChunkInternalAsync(clip, chunkIndex: 0, offset: TimeSpan.Zero, playAfterOpen: true, requestId, ct);
+                // Open paused so every camera decodes its first frame before the loading overlay clears;
+                // playback is started below, after the reveal, so the clip flows from a still frame into motion.
+                await OpenChunkInternalAsync(clip, chunkIndex: 0, offset: TimeSpan.Zero, playAfterOpen: false, requestId, ct);
             }, replacePlaybackCts: true);
         }
         catch (OperationCanceledException)
@@ -408,6 +410,26 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
             if (IsRequestActive(requestId))
             {
                 IsLoading = false;
+            }
+        }
+
+        // The first frame is decoded and the overlay has cleared; start playback now so the revealed
+        // still frame flows straight into motion instead of visibly loading in after the overlay is gone.
+        if (IsRequestActive(requestId) && IsMediaOpen && _openedClip == clip)
+        {
+            try
+            {
+                await RunSerializedPlaybackOperationAsync(async _ =>
+                {
+                    if (!IsRequestActive(requestId) || _openedClip != clip)
+                        return;
+
+                    await PlayOpenPlayersAsync();
+                    IsPlaying = true;
+                });
+            }
+            catch (OperationCanceledException)
+            {
             }
         }
     }
@@ -541,7 +563,7 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
             }
             else
             {
-                await PauseOpenPlayersAsync();
+                // Freshly opened players are already paused (AutoPlay is off), so just reflect the state.
                 IsPlaying = false;
             }
 

--- a/SentryReplay/Playback/VideoPlayerController.cs
+++ b/SentryReplay/Playback/VideoPlayerController.cs
@@ -387,9 +387,7 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
                     _timeline.Count,
                     Duration,
                     requestId);
-                // Open paused so every camera decodes its first frame before the loading overlay clears;
-                // playback is started below, after the reveal, so the clip flows from a still frame into motion.
-                await OpenChunkInternalAsync(clip, chunkIndex: 0, offset: TimeSpan.Zero, playAfterOpen: false, requestId, ct);
+                await OpenChunkInternalAsync(clip, chunkIndex: 0, offset: TimeSpan.Zero, playAfterOpen: true, requestId, ct);
             }, replacePlaybackCts: true);
         }
         catch (OperationCanceledException)
@@ -410,26 +408,6 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
             if (IsRequestActive(requestId))
             {
                 IsLoading = false;
-            }
-        }
-
-        // The first frame is decoded and the overlay has cleared; start playback now so the revealed
-        // still frame flows straight into motion instead of visibly loading in after the overlay is gone.
-        if (IsRequestActive(requestId) && IsMediaOpen && _openedClip == clip)
-        {
-            try
-            {
-                await RunSerializedPlaybackOperationAsync(async _ =>
-                {
-                    if (!IsRequestActive(requestId) || _openedClip != clip)
-                        return;
-
-                    await PlayOpenPlayersAsync();
-                    IsPlaying = true;
-                });
-            }
-            catch (OperationCanceledException)
-            {
             }
         }
     }
@@ -563,7 +541,7 @@ public sealed partial class VideoPlayerController : ObservableObject, IDisposabl
             }
             else
             {
-                // Freshly opened players are already paused (AutoPlay is off), so just reflect the state.
+                await PauseOpenPlayersAsync();
                 IsPlaying = false;
             }
 


### PR DESCRIPTION
## What

A set of changes to make the app feel more fluid and responsive. (Squash-merge — the branch has an add-then-revert detour from exploring a video-overlay approach that didn't pan out; the net change is below.)

### 1. Load clips off the UI thread
`LoadClips` scanned the disk (`CamStorage.Map`) synchronously on the UI thread from both startup and the folder picker, freezing the window during the scan (174 clips ≈ 140 ms on a real archive; worse for larger ones). Now `LoadClipsAsync` runs the scan via `Task.Run`; the continuation resumes on the UI thread (WPF `SynchronizationContext`), so all view-model state is still mutated there. Sibling of the playback-load fix in #33.

### 2. Smoother clip switching (no loading-screen flash)
The video hosts now stay visible while a selected clip loads, so switching clips just shows the players briefly blank until the first frame decodes — instead of collapsing the video, flashing a full loading screen, and popping back. Less on-screen churn. The full-screen overlay is now reserved for the genuinely no-video states (scanning with no clip selected, errors, the empty state).

### 3. Fixed the sidebar flicker
`RefreshClipState()` re-notified `FilteredClips` on every clip change, rebuilding the list and retriggering its fade. It's now only notified when the list actually changes (folder load / filter text).

### 4. Subtle animations
- Window fades in on launch (hardened so a missed `Loaded` can't leave it invisible).
- Status overlay + About page fade in.
- Buttons scale-down on press; camera-view tiles lift on hover.
- The clip list fades in when its contents change (load/filter) — not per-item, so no flicker while scrolling.

## Notes / constraints

- WPF **airspace**: the Flyleaf video is a separate native surface that draws on top of WPF, so a WPF panel can't cover it. That's why a clip's load can't be hidden behind a loading screen — hence the "players show directly while loading" behavior above, which reads as cleaner anyway.
- `MainWindowViewModel.LoadClips` is now `LoadClipsAsync`; callers already `await` it.

## Verification

93 tests pass; build + `dotnet format` clean; smoke-launched on a real 174-clip archive (async scan, playback, animations) with no crashes. Animation/feel verified interactively by the maintainer.