### PR TITLE
Unified camera panel (no-reparent) — prototype

### DIFF
--- a/SentryReplay/CameraLayoutPanel.cs
+++ b/SentryReplay/CameraLayoutPanel.cs
@@ -1,0 +1,117 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace SentryReplay;
+
+/// <summary>
+/// Arranges the four camera hosts without ever reparenting them: a 2x2 grid, or one primary view filling
+/// the top with the other three as a strip of tiles along the bottom. Switching views only re-arranges,
+/// so each Flyleaf surface resizes in place (no reparent flash). Identify each child with the attached
+/// <see cref="CameraProperty"/>; drive the layout with <see cref="SelectedCameraView"/>.
+/// </summary>
+public sealed class CameraLayoutPanel : Panel
+{
+    private const double Gap = 2;
+    private const double TileStripFraction = 0.22;
+
+    private static readonly string[] CameraOrder =
+    [
+        MainWindowViewModel.FrontCameraView,
+        MainWindowViewModel.RearCameraView,
+        MainWindowViewModel.LeftCameraView,
+        MainWindowViewModel.RightCameraView,
+    ];
+
+    public static readonly DependencyProperty CameraProperty = DependencyProperty.RegisterAttached(
+        "Camera",
+        typeof(string),
+        typeof(CameraLayoutPanel),
+        new PropertyMetadata(null));
+
+    public static string GetCamera(DependencyObject element) => (string)element.GetValue(CameraProperty);
+
+    public static void SetCamera(DependencyObject element, string value) => element.SetValue(CameraProperty, value);
+
+    public static readonly DependencyProperty SelectedCameraViewProperty = DependencyProperty.Register(
+        nameof(SelectedCameraView),
+        typeof(string),
+        typeof(CameraLayoutPanel),
+        new FrameworkPropertyMetadata(MainWindowViewModel.FrontCameraView, FrameworkPropertyMetadataOptions.AffectsArrange));
+
+    public string SelectedCameraView
+    {
+        get => (string)GetValue(SelectedCameraViewProperty);
+        set => SetValue(SelectedCameraViewProperty, value);
+    }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        foreach (UIElement child in InternalChildren)
+        {
+            child.Measure(availableSize);
+        }
+
+        return availableSize;
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        if (SelectedCameraView == MainWindowViewModel.GridCameraView)
+        {
+            ArrangeGrid(finalSize);
+        }
+        else
+        {
+            ArrangeSingle(finalSize);
+        }
+
+        return finalSize;
+    }
+
+    private void ArrangeGrid(Size size)
+    {
+        var cellWidth = (size.Width - Gap) / 2;
+        var cellHeight = (size.Height - Gap) / 2;
+        var right = cellWidth + Gap;
+        var bottom = cellHeight + Gap;
+
+        ArrangeCamera(MainWindowViewModel.FrontCameraView, new Rect(0, 0, cellWidth, cellHeight));
+        ArrangeCamera(MainWindowViewModel.RearCameraView, new Rect(right, 0, cellWidth, cellHeight));
+        ArrangeCamera(MainWindowViewModel.LeftCameraView, new Rect(0, bottom, cellWidth, cellHeight));
+        ArrangeCamera(MainWindowViewModel.RightCameraView, new Rect(right, bottom, cellWidth, cellHeight));
+    }
+
+    private void ArrangeSingle(Size size)
+    {
+        var stripHeight = size.Height * TileStripFraction;
+        var primaryHeight = Math.Max(0, size.Height - stripHeight - Gap);
+
+        ArrangeCamera(SelectedCameraView, new Rect(0, 0, size.Width, primaryHeight));
+
+        var tiles = CameraOrder.Where(camera => camera != SelectedCameraView).ToArray();
+        if (tiles.Length == 0)
+        {
+            return;
+        }
+
+        var tileWidth = (size.Width - (Gap * (tiles.Length - 1))) / tiles.Length;
+        var tileTop = primaryHeight + Gap;
+
+        for (var i = 0; i < tiles.Length; i++)
+        {
+            ArrangeCamera(tiles[i], new Rect(i * (tileWidth + Gap), tileTop, tileWidth, stripHeight));
+        }
+    }
+
+    private void ArrangeCamera(string camera, Rect rect)
+    {
+        foreach (UIElement child in InternalChildren)
+        {
+            if (GetCamera(child) == camera)
+            {
+                child.Arrange(rect);
+                return;
+            }
+        }
+    }
+}

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -419,10 +419,31 @@
 
                     <Grid x:Name="FlyleafHostPool"
                           Visibility="Collapsed">
-                        <fl:FlyleafHost x:Name="FrontFlyleafHost" />
-                        <fl:FlyleafHost x:Name="BackFlyleafHost" />
-                        <fl:FlyleafHost x:Name="LeftFlyleafHost" />
-                        <fl:FlyleafHost x:Name="RightFlyleafHost" />
+                        <!--
+                            A transparent overlay inside each host captures clicks on the video itself
+                            (the native surface otherwise swallows them) and switches to that camera. Tag is
+                            the camera-view key passed to SelectCameraViewCommand. See MainWindow.CameraHost_Click.
+                        -->
+                        <fl:FlyleafHost x:Name="FrontFlyleafHost">
+                            <Border Background="Transparent"
+                                    Tag="front"
+                                    MouseLeftButtonUp="CameraHost_Click" />
+                        </fl:FlyleafHost>
+                        <fl:FlyleafHost x:Name="BackFlyleafHost">
+                            <Border Background="Transparent"
+                                    Tag="rear"
+                                    MouseLeftButtonUp="CameraHost_Click" />
+                        </fl:FlyleafHost>
+                        <fl:FlyleafHost x:Name="LeftFlyleafHost">
+                            <Border Background="Transparent"
+                                    Tag="left"
+                                    MouseLeftButtonUp="CameraHost_Click" />
+                        </fl:FlyleafHost>
+                        <fl:FlyleafHost x:Name="RightFlyleafHost">
+                            <Border Background="Transparent"
+                                    Tag="right"
+                                    MouseLeftButtonUp="CameraHost_Click" />
+                        </fl:FlyleafHost>
                     </Grid>
 
                     <!--  Video Player  -->

--- a/SentryReplay/MainWindow.xaml
+++ b/SentryReplay/MainWindow.xaml
@@ -417,35 +417,6 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
-                    <Grid x:Name="FlyleafHostPool"
-                          Visibility="Collapsed">
-                        <!--
-                            A transparent overlay inside each host captures clicks on the video itself
-                            (the native surface otherwise swallows them) and switches to that camera. Tag is
-                            the camera-view key passed to SelectCameraViewCommand. See MainWindow.CameraHost_Click.
-                        -->
-                        <fl:FlyleafHost x:Name="FrontFlyleafHost">
-                            <Border Background="Transparent"
-                                    Tag="front"
-                                    MouseLeftButtonUp="CameraHost_Click" />
-                        </fl:FlyleafHost>
-                        <fl:FlyleafHost x:Name="BackFlyleafHost">
-                            <Border Background="Transparent"
-                                    Tag="rear"
-                                    MouseLeftButtonUp="CameraHost_Click" />
-                        </fl:FlyleafHost>
-                        <fl:FlyleafHost x:Name="LeftFlyleafHost">
-                            <Border Background="Transparent"
-                                    Tag="left"
-                                    MouseLeftButtonUp="CameraHost_Click" />
-                        </fl:FlyleafHost>
-                        <fl:FlyleafHost x:Name="RightFlyleafHost">
-                            <Border Background="Transparent"
-                                    Tag="right"
-                                    MouseLeftButtonUp="CameraHost_Click" />
-                        </fl:FlyleafHost>
-                    </Grid>
-
                     <!--  Video Player  -->
                     <Grid Grid.RowSpan="2"
                           Visibility="{Binding ShowVideoHosts, Converter={local:BoolToVisibilityConverter}}">
@@ -460,113 +431,16 @@
                                 BorderThickness="1"
                                 ClipToBounds="True"
                                 CornerRadius="6">
-                            <Grid>
-                                <Grid Visibility="{Binding IsGridViewSelected, Converter={local:BoolToVisibilityConverter}}">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="*" />
-                                        <RowDefinition Height="*" />
-                                    </Grid.RowDefinitions>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
-
-                                    <Border Grid.Row="0"
-                                            Grid.Column="0"
-                                            Margin="0,0,1,1"
-                                            Background="Black"
-                                            ClipToBounds="True">
-                                        <Grid>
-                                            <ContentControl x:Name="GridFrontHostSlot" />
-                                            <Border Margin="10"
-                                                    Padding="8,3"
-                                                    HorizontalAlignment="Left"
-                                                    VerticalAlignment="Top"
-                                                    Background="#A0000000"
-                                                    CornerRadius="4">
-                                                <TextBlock Text="Front"
-                                                           FontSize="12"
-                                                           Foreground="White" />
-                                            </Border>
-                                        </Grid>
-                                    </Border>
-
-                                    <Border Grid.Row="0"
-                                            Grid.Column="1"
-                                            Margin="1,0,0,1"
-                                            Background="Black"
-                                            ClipToBounds="True">
-                                        <Grid>
-                                            <ContentControl x:Name="GridRearHostSlot" />
-                                            <Border Margin="10"
-                                                    Padding="8,3"
-                                                    HorizontalAlignment="Left"
-                                                    VerticalAlignment="Top"
-                                                    Background="#A0000000"
-                                                    CornerRadius="4">
-                                                <TextBlock Text="Rear"
-                                                           FontSize="12"
-                                                           Foreground="White" />
-                                            </Border>
-                                        </Grid>
-                                    </Border>
-
-                                    <Border Grid.Row="1"
-                                            Grid.Column="0"
-                                            Margin="0,1,1,0"
-                                            Background="Black"
-                                            ClipToBounds="True">
-                                        <Grid>
-                                            <ContentControl x:Name="GridLeftHostSlot" />
-                                            <Border Margin="10"
-                                                    Padding="8,3"
-                                                    HorizontalAlignment="Left"
-                                                    VerticalAlignment="Top"
-                                                    Background="#A0000000"
-                                                    CornerRadius="4">
-                                                <TextBlock Text="Left"
-                                                           FontSize="12"
-                                                           Foreground="White" />
-                                            </Border>
-                                        </Grid>
-                                    </Border>
-
-                                    <Border Grid.Row="1"
-                                            Grid.Column="1"
-                                            Margin="1,1,0,0"
-                                            Background="Black"
-                                            ClipToBounds="True">
-                                        <Grid>
-                                            <ContentControl x:Name="GridRightHostSlot" />
-                                            <Border Margin="10"
-                                                    Padding="8,3"
-                                                    HorizontalAlignment="Left"
-                                                    VerticalAlignment="Top"
-                                                    Background="#A0000000"
-                                                    CornerRadius="4">
-                                                <TextBlock Text="Right"
-                                                           FontSize="12"
-                                                           Foreground="White" />
-                                            </Border>
-                                        </Grid>
-                                    </Border>
-                                </Grid>
-
-                                <Grid Visibility="{Binding IsSingleCameraViewSelected, Converter={local:BoolToVisibilityConverter}}">
-                                    <ContentControl x:Name="PrimaryCameraHostSlot" />
-                                    <Border Margin="14"
-                                            Padding="10,4"
-                                            HorizontalAlignment="Left"
-                                            VerticalAlignment="Top"
-                                            Background="#A0000000"
-                                            CornerRadius="4">
-                                        <TextBlock Text="{Binding ActiveCameraLabel}"
-                                                   FontSize="13"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="White" />
-                                    </Border>
-                                </Grid>
-                            </Grid>
+                            <local:CameraLayoutPanel SelectedCameraView="{Binding SelectedCameraView}">
+                                <fl:FlyleafHost x:Name="FrontFlyleafHost"
+                                                local:CameraLayoutPanel.Camera="front" />
+                                <fl:FlyleafHost x:Name="BackFlyleafHost"
+                                                local:CameraLayoutPanel.Camera="rear" />
+                                <fl:FlyleafHost x:Name="LeftFlyleafHost"
+                                                local:CameraLayoutPanel.Camera="left" />
+                                <fl:FlyleafHost x:Name="RightFlyleafHost"
+                                                local:CameraLayoutPanel.Camera="right" />
+                            </local:CameraLayoutPanel>
                         </Border>
 
                         <Border Grid.Row="1"
@@ -629,11 +503,10 @@
                                                 CornerRadius="4">
                                             <Grid>
                                                 <ContentControl x:Name="FrontTileHostSlot" />
-                                                <!--  Single-screen icon: this camera is the main view (cf. the 2x2 grid icon)  -->
+                                                <!--  Single-screen switch-button icon (cf. the 2x2 grid icon)  -->
                                                 <Border Margin="18"
                                                         Background="{DynamicResource ControlFillColorSecondaryBrush}"
-                                                        CornerRadius="3"
-                                                        Visibility="{Binding IsFrontViewSelected, Converter={local:BoolToVisibilityConverter}}" />
+                                                        CornerRadius="3" />
                                             </Grid>
                                         </Border>
                                         <TextBlock Grid.Row="1"
@@ -661,11 +534,10 @@
                                                 CornerRadius="4">
                                             <Grid>
                                                 <ContentControl x:Name="RearTileHostSlot" />
-                                                <!--  Single-screen icon: this camera is the main view (cf. the 2x2 grid icon)  -->
+                                                <!--  Single-screen switch-button icon (cf. the 2x2 grid icon)  -->
                                                 <Border Margin="18"
                                                         Background="{DynamicResource ControlFillColorSecondaryBrush}"
-                                                        CornerRadius="3"
-                                                        Visibility="{Binding IsRearViewSelected, Converter={local:BoolToVisibilityConverter}}" />
+                                                        CornerRadius="3" />
                                             </Grid>
                                         </Border>
                                         <TextBlock Grid.Row="1"
@@ -693,11 +565,10 @@
                                                 CornerRadius="4">
                                             <Grid>
                                                 <ContentControl x:Name="LeftTileHostSlot" />
-                                                <!--  Single-screen icon: this camera is the main view (cf. the 2x2 grid icon)  -->
+                                                <!--  Single-screen switch-button icon (cf. the 2x2 grid icon)  -->
                                                 <Border Margin="18"
                                                         Background="{DynamicResource ControlFillColorSecondaryBrush}"
-                                                        CornerRadius="3"
-                                                        Visibility="{Binding IsLeftViewSelected, Converter={local:BoolToVisibilityConverter}}" />
+                                                        CornerRadius="3" />
                                             </Grid>
                                         </Border>
                                         <TextBlock Grid.Row="1"
@@ -725,11 +596,10 @@
                                                 CornerRadius="4">
                                             <Grid>
                                                 <ContentControl x:Name="RightTileHostSlot" />
-                                                <!--  Single-screen icon: this camera is the main view (cf. the 2x2 grid icon)  -->
+                                                <!--  Single-screen switch-button icon (cf. the 2x2 grid icon)  -->
                                                 <Border Margin="18"
                                                         Background="{DynamicResource ControlFillColorSecondaryBrush}"
-                                                        CornerRadius="3"
-                                                        Visibility="{Binding IsRightViewSelected, Converter={local:BoolToVisibilityConverter}}" />
+                                                        CornerRadius="3" />
                                             </Grid>
                                         </Border>
                                         <TextBlock Grid.Row="1"

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -10,9 +10,9 @@ using Serilog;
 namespace SentryReplay;
 
 /// <summary>
-/// Main WPF window. Owns only view concerns: window lifecycle, Flyleaf host layout, the seek
-/// slider input plumbing, and search-box focus. All state, commands, and orchestration live in
-/// <see cref="MainWindowViewModel"/>.
+/// Main WPF window. Owns only view concerns: window lifecycle, the seek-slider input plumbing, and
+/// search-box focus. The camera layout is handled by <see cref="CameraLayoutPanel"/> (no reparenting);
+/// all state, commands, and orchestration live in <see cref="MainWindowViewModel"/>.
 /// </summary>
 public partial class MainWindow : Window
 {
@@ -27,10 +27,8 @@ public partial class MainWindow : Window
         _viewModel = new MainWindowViewModel(
             () => VideoPlayerController.Create(FrontFlyleafHost, BackFlyleafHost, LeftFlyleafHost, RightFlyleafHost));
         _viewModel.SearchBoxFocusRequested += OnSearchBoxFocusRequested;
-        _viewModel.PropertyChanged += ViewModelOnPropertyChanged;
 
         DataContext = _viewModel;
-        UpdateCameraHostLayout();
     }
 
     private async void Window_ContentRendered(object sender, EventArgs e)
@@ -99,111 +97,10 @@ public partial class MainWindow : Window
         _viewModel.OnSeekSliderValueChanged();
     }
 
-    private void ViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName == nameof(MainWindowViewModel.SelectedCameraView))
-        {
-            UpdateCameraHostLayout();
-        }
-    }
-
     private void OnSearchBoxFocusRequested(object sender, EventArgs e)
     {
         SearchBox.Focus();
         SearchBox.SelectAll();
-    }
-
-    private void CameraHost_Click(object sender, MouseButtonEventArgs e)
-    {
-        // Clicking a player (including the mini previews) switches to that camera. A transparent overlay
-        // inside the host receives the click that the native video surface would otherwise swallow.
-        if (sender is FrameworkElement { Tag: string cameraView })
-        {
-            _viewModel.SelectCameraViewCommand.Execute(cameraView);
-            e.Handled = true;
-        }
-    }
-
-    private void UpdateCameraHostLayout()
-    {
-        if (PrimaryCameraHostSlot is null)
-            return;
-
-        foreach (var (host, slot) in GetCameraHostLayout(_viewModel.SelectedCameraView))
-        {
-            MoveHostToSlot(host, slot);
-        }
-
-        // Force a synchronous layout pass so each moved host reaches its final bounds promptly. Note: a
-        // brief flash of the reparented Flyleaf surface at its old size is a known limitation here and is
-        // accepted (eliminating it would require not reparenting the hosts at all).
-        UpdateLayout();
-    }
-
-    private IReadOnlyList<(FlyleafHost Host, ContentControl Slot)> GetCameraHostLayout(string view) => view switch
-    {
-        MainWindowViewModel.GridCameraView =>
-        [
-            (FrontFlyleafHost, GridFrontHostSlot),
-            (BackFlyleafHost, GridRearHostSlot),
-            (LeftFlyleafHost, GridLeftHostSlot),
-            (RightFlyleafHost, GridRightHostSlot),
-        ],
-        MainWindowViewModel.RearCameraView =>
-        [
-            (BackFlyleafHost, PrimaryCameraHostSlot),
-            (FrontFlyleafHost, FrontTileHostSlot),
-            (LeftFlyleafHost, LeftTileHostSlot),
-            (RightFlyleafHost, RightTileHostSlot),
-        ],
-        MainWindowViewModel.LeftCameraView =>
-        [
-            (LeftFlyleafHost, PrimaryCameraHostSlot),
-            (FrontFlyleafHost, FrontTileHostSlot),
-            (BackFlyleafHost, RearTileHostSlot),
-            (RightFlyleafHost, RightTileHostSlot),
-        ],
-        MainWindowViewModel.RightCameraView =>
-        [
-            (RightFlyleafHost, PrimaryCameraHostSlot),
-            (FrontFlyleafHost, FrontTileHostSlot),
-            (BackFlyleafHost, RearTileHostSlot),
-            (LeftFlyleafHost, LeftTileHostSlot),
-        ],
-        _ =>
-        [
-            (FrontFlyleafHost, PrimaryCameraHostSlot),
-            (BackFlyleafHost, RearTileHostSlot),
-            (LeftFlyleafHost, LeftTileHostSlot),
-            (RightFlyleafHost, RightTileHostSlot),
-        ],
-    };
-
-    private static void MoveHostToSlot(FlyleafHost host, ContentControl slot)
-    {
-        if (ReferenceEquals(slot.Content, host))
-            return;
-
-        RemoveHostFromParent(host);
-        slot.Content = host;
-    }
-
-    private static void RemoveHostFromParent(FlyleafHost host)
-    {
-        switch (host.Parent)
-        {
-            case ContentControl contentControl when ReferenceEquals(contentControl.Content, host):
-                contentControl.Content = null;
-                break;
-
-            case Panel panel:
-                panel.Children.Remove(host);
-                break;
-
-            case Decorator decorator when ReferenceEquals(decorator.Child, host):
-                decorator.Child = null;
-                break;
-        }
     }
 
     private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -113,6 +113,17 @@ public partial class MainWindow : Window
         SearchBox.SelectAll();
     }
 
+    private void CameraHost_Click(object sender, MouseButtonEventArgs e)
+    {
+        // Clicking a player (including the mini previews) switches to that camera. A transparent overlay
+        // inside the host receives the click that the native video surface would otherwise swallow.
+        if (sender is FrameworkElement { Tag: string cameraView })
+        {
+            _viewModel.SelectCameraViewCommand.Execute(cameraView);
+            e.Handled = true;
+        }
+    }
+
     private void UpdateCameraHostLayout()
     {
         if (PrimaryCameraHostSlot is null)


### PR DESCRIPTION
## Prototype for evaluation (not ready to merge)

Reworks the video area into a single `CameraLayoutPanel` holding all four players, so they're **never reparented** — switching views just re-arranges/resizes them in place, which eliminates the camera-switch flash.

- **Grid view:** 2x2.
- **Single view:** selected camera fills the top; the other three as a strip of tiles along the bottom of the video area.
- The bottom dashcam bar is now **static switch buttons** (single-screen icon + label) since the live previews moved into the panel.
- Removed all the reparenting code-behind (`UpdateCameraHostLayout`/`MoveHostToSlot`/etc.).

## Known gaps in this prototype
- **Click-to-switch on the in-video minis isn't wired** — the transparent overlay-inside-host click didn't actually fire (Flyleaf surface input is trickier than the docs implied). Switching is via the bottom buttons for now; I'll solve in-video clicks properly if you like this layout.
- Camera labels over the video aren't added yet.

## Verification
Build clean, 93 tests pass, smoke-launch clean. The layout itself needs your eyes.