### PR TITLE
Click a player to switch cameras

### DIFF
--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -132,7 +132,7 @@ public partial class MainWindow : Window
             if (host.Surface is { } surface && _clickHookedSurfaces.Add(surface))
             {
                 surface.AddHandler(
-                    MouseLeftButtonDownEvent,
+                    MouseLeftButtonUpEvent,
                     new MouseButtonEventHandler((_, e) =>
                     {
                         _viewModel.SelectCameraViewCommand.Execute(cameraView);

--- a/SentryReplay/MainWindow.xaml.cs
+++ b/SentryReplay/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ namespace SentryReplay;
 public partial class MainWindow : Window
 {
     private readonly MainWindowViewModel _viewModel;
+    private readonly HashSet<Window> _clickHookedSurfaces = [];
     private bool _isClosing;
     private bool _isReadyToClose;
 
@@ -30,6 +31,14 @@ public partial class MainWindow : Window
         _viewModel.PropertyChanged += ViewModelOnPropertyChanged;
 
         DataContext = _viewModel;
+
+        // Clicking a player (incl. the mini previews) switches to that camera. Flyleaf renders each camera
+        // into its own native surface, so the click must be caught on the surface, not via a WPF overlay.
+        HookCameraClick(FrontFlyleafHost, MainWindowViewModel.FrontCameraView);
+        HookCameraClick(BackFlyleafHost, MainWindowViewModel.RearCameraView);
+        HookCameraClick(LeftFlyleafHost, MainWindowViewModel.LeftCameraView);
+        HookCameraClick(RightFlyleafHost, MainWindowViewModel.RightCameraView);
+
         UpdateCameraHostLayout();
     }
 
@@ -111,6 +120,27 @@ public partial class MainWindow : Window
     {
         SearchBox.Focus();
         SearchBox.SelectAll();
+    }
+
+    // The FlyleafHost creates its native Surface window when it loads (and reuses it across reparenting),
+    // so subscribe once it exists. handledEventsToo ensures we still see the click if Flyleaf marks it
+    // handled, and the HashSet guards against re-subscribing when Loaded fires again on a reparent.
+    private void HookCameraClick(FlyleafHost host, string cameraView)
+    {
+        host.Loaded += (_, _) =>
+        {
+            if (host.Surface is { } surface && _clickHookedSurfaces.Add(surface))
+            {
+                surface.AddHandler(
+                    MouseLeftButtonDownEvent,
+                    new MouseButtonEventHandler((_, e) =>
+                    {
+                        _viewModel.SelectCameraViewCommand.Execute(cameraView);
+                        e.Handled = true;
+                    }),
+                    handledEventsToo: true);
+            }
+        };
     }
 
     private void UpdateCameraHostLayout()


### PR DESCRIPTION
## What

You couldn't click a mini camera preview to switch to it — the click landed on Flyleaf's native video surface, which WPF never sees (and the earlier WPF-overlay attempt was on the wrong layer, so it never fired).

The fix hooks the click on **Flyleaf's own surface window**: `FlyleafHost.Surface` is a public `Window`, created when the host loads and reused across reparenting. `MainWindow.HookCameraClick` subscribes to each surface's `MouseLeftButtonDown` (with `handledEventsToo` so Flyleaf marking it handled doesn't hide it) and runs `SelectCameraViewCommand` for that camera. A `HashSet` guards against re-subscribing when `Loaded` fires again on a reparent.

Clicking any player — a mini preview or the big one — now switches that camera to the main view. (No layout change; the dedicated bottom bar stays.)

## Verification

Build clean, 93 tests pass, smoke-launch clean. The click behavior needs your eyes (can't be exercised headlessly).

## Note

This is the click-to-switch piece only. The reparent flash and the inability to draw WPF over the video are inherent to Flyleaf-on-WPF (no compositing / D3DImage support, per the maintainer) and remain accepted.